### PR TITLE
feat: refactor outputting

### DIFF
--- a/connection_impl.go
+++ b/connection_impl.go
@@ -165,9 +165,8 @@ func (c *connection) MallocLen() (length int) {
 // If empty, it will call syscall.Write to send data directly,
 // otherwise the buffer will be sent asynchronously by the epoll trigger.
 func (c *connection) Flush() error {
-	if c.IsActive() && c.lock(outputBuffer) {
+	if c.IsActive() {
 		c.outputBuffer.Flush()
-		c.unlock(outputBuffer)
 		return c.flush()
 	}
 	return Exception(ErrConnClosed, "when flush")

--- a/connection_impl.go
+++ b/connection_impl.go
@@ -173,15 +173,15 @@ func (c *connection) Flush() error {
 		return Exception(ErrConnClosed, "when flush")
 	}
 	registered := false
-	if err := c.outputBuffer.Flush(); err != nil {
-		return err
-	}
 	defer func() {
 		if registered {
 			c.operator.Control(PollRW2R)
 		}
 		c.unlock(outputting)
 	}()
+	if err := c.outputBuffer.Flush(); err != nil {
+		return err
+	}
 	for !c.outputBuffer.IsEmpty() {
 		// TODO: Let the upper layer pass in whether to use ZeroCopy.
 		var bs = c.outputBuffer.GetBytes(c.outputBarrier.bs)

--- a/connection_impl.go
+++ b/connection_impl.go
@@ -175,7 +175,7 @@ func (c *connection) Flush() error {
 	registered := false
 	defer func() {
 		if registered {
-			c.operator.Control(PollRW2R)
+			c.operator.Control(PollW2R)
 		}
 		c.unlock(outputting)
 	}()
@@ -200,7 +200,7 @@ func (c *connection) Flush() error {
 			if !registered {
 				registered = true
 				// wait for writeable
-				err = c.operator.Control(PollR2RW)
+				err = c.operator.Control(PollR2W)
 				if err != nil {
 					return Exception(err, "when flush")
 				}

--- a/connection_lock.go
+++ b/connection_lock.go
@@ -33,7 +33,6 @@ const (
 	closing key = iota
 	processing
 	writing
-	inputBuffer
 	// total must be at the bottom.
 	total
 )

--- a/connection_lock.go
+++ b/connection_lock.go
@@ -34,7 +34,6 @@ const (
 	processing
 	writing
 	inputBuffer
-	outputBuffer
 	// total must be at the bottom.
 	total
 )

--- a/connection_lock.go
+++ b/connection_lock.go
@@ -32,7 +32,6 @@ type key int32
 const (
 	closing key = iota
 	processing
-	reading
 	writing
 	inputBuffer
 	outputBuffer

--- a/connection_onevent.go
+++ b/connection_onevent.go
@@ -17,6 +17,7 @@ package netpoll
 import (
 	"context"
 	"log"
+	"sync"
 	"sync/atomic"
 
 	"github.com/bytedance/gopkg/util/gopool"
@@ -43,9 +44,10 @@ type gracefulExit interface {
 // OnPrepare, OnRequest, CloseCallback share the lock processing,
 // which is a CAS lock and can only be cleared by OnRequest.
 type onEvent struct {
-	ctx       context.Context
-	process   atomic.Value // value is OnRequest
-	callbacks atomic.Value // value is latest *callbackNode
+	ctx           context.Context
+	process       atomic.Value // value is OnRequest
+	callbacks     atomic.Value // value is latest *callbackNode
+	callbacksOnce sync.Once
 }
 
 type callbackNode struct {
@@ -140,9 +142,11 @@ func (c *connection) closeCallback(needLock bool) (err error) {
 	if latest == nil {
 		return nil
 	}
-	for callback := latest.(*callbackNode); callback != nil; callback = callback.pre {
-		callback.fn(c)
-	}
+	c.callbacksOnce.Do(func() {
+		for callback := latest.(*callbackNode); callback != nil; callback = callback.pre {
+			callback.fn(c)
+		}
+	})
 	return nil
 }
 

--- a/connection_onevent.go
+++ b/connection_onevent.go
@@ -146,7 +146,6 @@ func (c *connection) closeCallback() (err error) {
 	if !c.lock(processing) {
 		return nil
 	}
-	defer c.unlock(processing)
 
 	// close callback should only been executed once
 	if !c.stop(outputting) {

--- a/connection_onevent.go
+++ b/connection_onevent.go
@@ -89,6 +89,11 @@ func (c *connection) onPrepare(prepare OnPrepare) (err error) {
 	return nil
 }
 
+func (c *connection) onWrite(p Poll) (err error) {
+	c.triggerWrite(nil)
+	return nil
+}
+
 // onRequest is also responsible for executing the callbacks after the connection has been closed.
 func (c *connection) onRequest() (err error) {
 	var process = c.process.Load()

--- a/connection_onevent.go
+++ b/connection_onevent.go
@@ -22,6 +22,15 @@ import (
 	"github.com/bytedance/gopkg/util/gopool"
 )
 
+var runTask = gopool.CtxGo
+
+func disableGopool() error {
+	runTask = func(ctx context.Context, f func()) {
+		go f()
+	}
+	return nil
+}
+
 // ------------------------------------ implement OnPrepare, OnRequest, CloseCallback ------------------------------------
 
 type gracefulExit interface {
@@ -116,7 +125,7 @@ func (c *connection) onRequest() (err error) {
 			goto START
 		}
 	}
-	gopool.CtxGo(c.ctx, task)
+	runTask(c.ctx, task)
 	return nil
 }
 

--- a/connection_reactor.go
+++ b/connection_reactor.go
@@ -59,10 +59,8 @@ func (c *connection) onClose() error {
 // closeBuffer recycle input & output LinkBuffer.
 func (c *connection) closeBuffer() {
 	c.stop(writing)
-	if c.lock(inputBuffer) {
-		c.inputBuffer.Close()
-		barrierPool.Put(c.inputBarrier)
-	}
+	c.inputBuffer.Close()
+	barrierPool.Put(c.inputBarrier)
 	c.outputBuffer.Close()
 	barrierPool.Put(c.outputBarrier)
 }

--- a/connection_reactor.go
+++ b/connection_reactor.go
@@ -16,7 +16,6 @@ package netpoll
 
 import (
 	"sync/atomic"
-	"syscall"
 )
 
 // ------------------------------------------ implement FDOperator ------------------------------------------
@@ -30,7 +29,7 @@ func (c *connection) onHup(p Poll) error {
 		// It can be confirmed that the OnRequest goroutine has been exited before closecallback executing,
 		// and it is safe to close the buffer at this time.
 		if process, _ := c.process.Load().(OnRequest); process != nil {
-			c.closeCallback(true)
+			c.closeCallback()
 		}
 	}
 	return nil
@@ -45,20 +44,18 @@ func (c *connection) onClose() error {
 		}
 		c.triggerRead()
 		c.triggerWrite(ErrConnClosed)
-		c.closeCallback(true)
-		return nil
+		return c.closeCallback()
 	}
 	if c.isCloseBy(poller) {
 		// Connection with OnRequest of nil
 		// relies on the user to actively close the connection to recycle resources.
-		c.closeCallback(true)
+		return c.closeCallback()
 	}
 	return nil
 }
 
 // closeBuffer recycle input & output LinkBuffer.
 func (c *connection) closeBuffer() {
-	c.stop(writing)
 	c.inputBuffer.Close()
 	barrierPool.Put(c.inputBarrier)
 	c.outputBuffer.Close()
@@ -93,13 +90,14 @@ func (c *connection) inputAck(n int) (err error) {
 
 // outputs implements FDOperator.
 func (c *connection) outputs(vs [][]byte) (rs [][]byte, supportZeroCopy bool) {
-	if !c.lock(writing) {
-		return rs, c.supportZeroCopy
+	if !c.lock(outputting) {
+		return
 	}
 	if c.outputBuffer.IsEmpty() {
-		c.unlock(writing)
+		c.unlock(outputting)
 		c.rw2r()
-		return rs, c.supportZeroCopy
+		c.triggerWrite(nil)
+		return
 	}
 	rs = c.outputBuffer.GetBytes(vs)
 	return rs, c.supportZeroCopy
@@ -111,10 +109,11 @@ func (c *connection) outputAck(n int) (err error) {
 		c.outputBuffer.Skip(n)
 		c.outputBuffer.Release()
 	}
-	// must unlock before check empty
-	c.unlock(writing)
+	// unlock before trigger write
+	c.unlock(outputting)
 	if c.outputBuffer.IsEmpty() {
 		c.rw2r()
+		c.triggerWrite(nil)
 	}
 	return nil
 }
@@ -122,47 +121,4 @@ func (c *connection) outputAck(n int) (err error) {
 // rw2r removed the monitoring of write events.
 func (c *connection) rw2r() {
 	c.operator.Control(PollRW2R)
-	c.triggerWrite(nil)
-}
-
-// flush write data directly.
-func (c *connection) flush() error {
-	if !c.lock(writing) {
-		return nil
-	}
-	locked := true
-	defer func() {
-		if locked {
-			c.unlock(writing)
-		}
-	}()
-	if c.outputBuffer.IsEmpty() {
-		return nil
-	}
-	// TODO: Let the upper layer pass in whether to use ZeroCopy.
-	var bs = c.outputBuffer.GetBytes(c.outputBarrier.bs)
-	var n, err = sendmsg(c.fd, bs, c.outputBarrier.ivs, false && c.supportZeroCopy)
-	if err != nil && err != syscall.EAGAIN {
-		return Exception(err, "when flush")
-	}
-	if n > 0 {
-		err = c.outputBuffer.Skip(n)
-		c.outputBuffer.Release()
-		if err != nil {
-			return Exception(err, "when flush")
-		}
-	}
-	// return if write all buffer.
-	if c.outputBuffer.IsEmpty() {
-		return nil
-	}
-	err = c.operator.Control(PollR2RW)
-	if err != nil {
-		return Exception(err, "when flush")
-	}
-
-	locked = false
-	c.unlock(writing)
-	err = <-c.writeTrigger
-	return err
 }

--- a/connection_reactor.go
+++ b/connection_reactor.go
@@ -44,7 +44,8 @@ func (c *connection) onClose() error {
 		}
 		c.triggerRead()
 		c.triggerWrite(ErrConnClosed)
-		return c.closeCallback()
+		c.closeCallback()
+		return nil
 	}
 	if c.isCloseBy(poller) {
 		// Connection with OnRequest of nil

--- a/connection_reactor.go
+++ b/connection_reactor.go
@@ -63,10 +63,8 @@ func (c *connection) closeBuffer() {
 		c.inputBuffer.Close()
 		barrierPool.Put(c.inputBarrier)
 	}
-	if c.lock(outputBuffer) {
-		c.outputBuffer.Close()
-		barrierPool.Put(c.outputBarrier)
-	}
+	c.outputBuffer.Close()
+	barrierPool.Put(c.outputBarrier)
 }
 
 // inputs implements FDOperator.

--- a/connection_reactor.go
+++ b/connection_reactor.go
@@ -58,7 +58,6 @@ func (c *connection) onClose() error {
 
 // closeBuffer recycle input & output LinkBuffer.
 func (c *connection) closeBuffer() {
-	c.stop(reading)
 	c.stop(writing)
 	if c.lock(inputBuffer) {
 		c.inputBuffer.Close()
@@ -72,10 +71,6 @@ func (c *connection) closeBuffer() {
 
 // inputs implements FDOperator.
 func (c *connection) inputs(vs [][]byte) (rs [][]byte) {
-	if !c.lock(reading) {
-		return rs
-	}
-
 	n := int(atomic.LoadInt32(&c.waitReadSize))
 	if n <= pagesize {
 		return c.inputBuffer.Book(pagesize, vs)
@@ -95,7 +90,6 @@ func (c *connection) inputAck(n int) (err error) {
 	}
 	lack := atomic.AddInt32(&c.waitReadSize, int32(-n))
 	err = c.inputBuffer.BookAck(n, lack <= 0)
-	c.unlock(reading)
 	c.triggerRead()
 	c.onRequest()
 	return err

--- a/net_listener.go
+++ b/net_listener.go
@@ -17,6 +17,7 @@
 package netpoll
 
 import (
+	"errors"
 	"net"
 	"os"
 	"syscall"
@@ -32,41 +33,44 @@ type Listener interface {
 
 // CreateListener return a new Listener.
 func CreateListener(network, addr string) (l Listener, err error) {
-	ln := &listener{
-		network: network,
-		addr:    addr,
-	}
-
-	defer func() {
-		if err != nil {
-			ln.Close()
-		}
-	}()
-
-	if ln.network == "udp" {
+	if network == "udp" {
 		// TODO: udp listener.
-		ln.pconn, err = net.ListenPacket(ln.network, ln.addr)
-		if err != nil {
-			return nil, err
-		}
-		ln.lnaddr = ln.pconn.LocalAddr()
-		switch pconn := ln.pconn.(type) {
-		case *net.UDPConn:
-			ln.file, err = pconn.File()
-		}
-	} else {
-		// tcp, tcp4, tcp6, unix
-		ln.ln, err = net.Listen(ln.network, ln.addr)
-		if err != nil {
-			return nil, err
-		}
-		ln.lnaddr = ln.ln.Addr()
-		switch netln := ln.ln.(type) {
-		case *net.TCPListener:
-			ln.file, err = netln.File()
-		case *net.UnixListener:
-			ln.file, err = netln.File()
-		}
+		return udpListener(network, addr)
+	}
+	// tcp, tcp4, tcp6, unix
+	ln, err := net.Listen(network, addr)
+	if err != nil {
+		return nil, err
+	}
+	return ConvertListener(ln)
+}
+
+// ConvertListener converts net.Listener to Listener
+func ConvertListener(l net.Listener) (nl Listener, err error) {
+	if tmp, ok := l.(Listener); ok {
+		return tmp, nil
+	}
+	ln := &listener{}
+	ln.ln = l
+	ln.addr = l.Addr()
+	err = ln.parseFD()
+	if err != nil {
+		return nil, err
+	}
+	return ln, syscall.SetNonblock(ln.fd, true)
+}
+
+// TODO: udpListener does not work now.
+func udpListener(network, addr string) (l Listener, err error) {
+	ln := &listener{}
+	ln.pconn, err = net.ListenPacket(network, addr)
+	if err != nil {
+		return nil, err
+	}
+	ln.addr = ln.pconn.LocalAddr()
+	switch pconn := ln.pconn.(type) {
+	case *net.UDPConn:
+		ln.file, err = pconn.File()
 	}
 	if err != nil {
 		return nil, err
@@ -78,13 +82,11 @@ func CreateListener(network, addr string) (l Listener, err error) {
 var _ net.Listener = &listener{}
 
 type listener struct {
-	ln      net.Listener   // tcp|unix listener
-	lnaddr  net.Addr       // listener's local addr
-	pconn   net.PacketConn // udp listener
-	file    *os.File
-	fd      int
-	network string // tcp, tcp4, tcp6, udp, udp4, udp6, unix
-	addr    string
+	fd    int
+	addr  net.Addr       // listener's local addr
+	ln    net.Listener   // tcp|unix listener
+	pconn net.PacketConn // udp listener
+	file  *os.File
 }
 
 // Accept implements Listener.
@@ -103,8 +105,8 @@ func (ln *listener) Accept() (net.Conn, error) {
 	}
 	var nfd = &netFD{}
 	nfd.fd = fd
-	nfd.network = ln.network
-	nfd.localAddr = ln.lnaddr
+	nfd.localAddr = ln.addr
+	nfd.network = ln.addr.Network()
 	nfd.remoteAddr = sockaddrToAddr(sa)
 	return nfd, nil
 }
@@ -128,18 +130,31 @@ func (ln *listener) Close() error {
 	if ln.pconn != nil {
 		ln.pconn.Close()
 	}
-	if ln.network == "unix" {
-		os.RemoveAll(ln.addr)
-	}
 	return nil
 }
 
 // Addr implements Listener.
 func (ln *listener) Addr() net.Addr {
-	return ln.lnaddr
+	return ln.addr
 }
 
 // Fd implements Listener.
 func (ln *listener) Fd() (fd int) {
 	return ln.fd
+}
+
+func (ln *listener) parseFD() (err error) {
+	switch netln := ln.ln.(type) {
+	case *net.TCPListener:
+		ln.file, err = netln.File()
+	case *net.UnixListener:
+		ln.file, err = netln.File()
+	default:
+		return errors.New("listener type can't support")
+	}
+	if err != nil {
+		return err
+	}
+	ln.fd = int(ln.file.Fd())
+	return nil
 }

--- a/net_listener_test.go
+++ b/net_listener_test.go
@@ -96,3 +96,22 @@ func TestListenerDialer(t *testing.T) {
 		Equal(t, atomic.LoadInt32(&closed), int32(1))
 	}
 }
+
+func TestConvertListener(t *testing.T) {
+	network, address := "unix", "mock.test.sock"
+	ln, err := net.Listen(network, address)
+	if err != nil {
+		panic(err)
+	}
+	udsln, _ := ln.(*net.UnixListener)
+	// udsln.SetUnlinkOnClose(false)
+
+	nln, err := ConvertListener(udsln)
+	if err != nil {
+		panic(err)
+	}
+	err = nln.Close()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/netpoll.go
+++ b/netpoll.go
@@ -18,6 +18,7 @@ package netpoll
 
 import (
 	"context"
+	"net"
 	"sync"
 )
 
@@ -26,7 +27,7 @@ type EventLoop interface {
 	// Serve registers a listener and runs blockingly to provide services, including listening to ports,
 	// accepting connections and processing trans data. When an exception occurs or Shutdown is invoked,
 	// Serve will return an error which describes the specific reason.
-	Serve(ln Listener) error
+	Serve(ln net.Listener) error
 
 	// Shutdown is used to graceful exit.
 	// It will close all idle connections on the server, but will not change the underlying pollers.
@@ -101,9 +102,13 @@ type eventLoop struct {
 }
 
 // Serve implements EventLoop.
-func (evl *eventLoop) Serve(ln Listener) error {
+func (evl *eventLoop) Serve(ln net.Listener) error {
+	npln, err := ConvertListener(ln)
+	if err != nil {
+		return err
+	}
 	evl.Lock()
-	evl.svr = newServer(ln, evl.prepare, evl.quit)
+	evl.svr = newServer(npln, evl.prepare, evl.quit)
 	evl.svr.Run()
 	evl.Unlock()
 	return evl.waitQuit()

--- a/netpoll_options.go
+++ b/netpoll_options.go
@@ -35,6 +35,15 @@ func SetLoadBalance(lb LoadBalance) error {
 	return setLoadBalance(lb)
 }
 
+// DisableGopool will remove gopool(the goroutine pool used to run OnRequest),
+// which means that OnRequest will be run via `go OnRequest(...)`.
+// Usually, OnRequest will cause stack expansion, which can be solved by reusing goroutine.
+// But if you can confirm that the OnRequest will not cause stack expansion,
+// it is recommended to use DisableGopool to reduce redundancy and improve performance.
+func DisableGopool() error {
+	return disableGopool()
+}
+
 // WithOnPrepare registers the OnPrepare method to EventLoop.
 func WithOnPrepare(onPrepare OnPrepare) Option {
 	return Option{func(op *options) {

--- a/nocopy_readwriter.go
+++ b/nocopy_readwriter.go
@@ -15,7 +15,6 @@
 package netpoll
 
 import (
-	"errors"
 	"fmt"
 	"io"
 )
@@ -40,7 +39,7 @@ type zcReader struct {
 // Next implements Reader.
 func (r *zcReader) Next(n int) (p []byte, err error) {
 	if err = r.waitRead(n); err != nil {
-		return p, fmt.Errorf("zcReader buffer next[%d] %w", n, err)
+		return p, err
 	}
 	return r.buf.Next(n)
 }
@@ -48,7 +47,7 @@ func (r *zcReader) Next(n int) (p []byte, err error) {
 // Peek implements Reader.
 func (r *zcReader) Peek(n int) (buf []byte, err error) {
 	if err = r.waitRead(n); err != nil {
-		return buf, fmt.Errorf("zcReader buffer peek[%d] %w", n, err)
+		return buf, err
 	}
 	return r.buf.Peek(n)
 }
@@ -56,7 +55,7 @@ func (r *zcReader) Peek(n int) (buf []byte, err error) {
 // Skip implements Reader.
 func (r *zcReader) Skip(n int) (err error) {
 	if err = r.waitRead(n); err != nil {
-		return fmt.Errorf("zcReader buffer skip[%d] %w", n, err)
+		return err
 	}
 	return r.buf.Skip(n)
 }
@@ -69,7 +68,7 @@ func (r *zcReader) Release() (err error) {
 // Slice implements Reader.
 func (r *zcReader) Slice(n int) (reader Reader, err error) {
 	if err = r.waitRead(n); err != nil {
-		return nil, fmt.Errorf("zcReader buffer slice[%d] %w", n, err)
+		return nil, err
 	}
 	return r.buf.Slice(n)
 }
@@ -82,7 +81,7 @@ func (r *zcReader) Len() (length int) {
 // ReadString implements Reader.
 func (r *zcReader) ReadString(n int) (s string, err error) {
 	if err = r.waitRead(n); err != nil {
-		return s, fmt.Errorf("zcReader buffer read string[%d] %w", n, err)
+		return s, err
 	}
 	return r.buf.ReadString(n)
 }
@@ -90,7 +89,7 @@ func (r *zcReader) ReadString(n int) (s string, err error) {
 // ReadBinary implements Reader.
 func (r *zcReader) ReadBinary(n int) (p []byte, err error) {
 	if err = r.waitRead(n); err != nil {
-		return p, fmt.Errorf("zcReader buffer read binary[%d] %w", n, err)
+		return p, err
 	}
 	return r.buf.ReadBinary(n)
 }
@@ -98,7 +97,7 @@ func (r *zcReader) ReadBinary(n int) (p []byte, err error) {
 // ReadByte implements Reader.
 func (r *zcReader) ReadByte() (b byte, err error) {
 	if err = r.waitRead(1); err != nil {
-		return b, fmt.Errorf("zcReader buffer read byte %w", err)
+		return b, err
 	}
 	return r.buf.ReadByte()
 }
@@ -108,7 +107,7 @@ func (r *zcReader) waitRead(n int) (err error) {
 		err = r.fill(n)
 		if err != nil {
 			if err == io.EOF {
-				err = errors.New("not enough")
+				err = Exception(ErrEOF, "")
 			}
 			return err
 		}

--- a/nocopy_readwriter_test.go
+++ b/nocopy_readwriter_test.go
@@ -15,6 +15,8 @@
 package netpoll
 
 import (
+	"errors"
+	"io"
 	"io/ioutil"
 	"testing"
 )
@@ -74,6 +76,18 @@ func TestZCWriter(t *testing.T) {
 	err = w.Flush()
 	MustNil(t, err)
 	Equal(t, w.buf.Len(), 0)
+}
+
+func TestZCEOF(t *testing.T) {
+	reader := &MockIOReadWriter{
+		read: func(p []byte) (n int, err error) {
+			return 0, io.EOF
+		},
+	}
+	r := newZCReader(reader)
+
+	_, err := r.Next(block8k)
+	MustTrue(t, errors.Is(err, ErrEOF))
 }
 
 type MockIOReadWriter struct {

--- a/poll.go
+++ b/poll.go
@@ -55,10 +55,10 @@ const (
 	// It is only used when calling the dialer's conn init.
 	PollModReadable PollEvent = 0x4
 
-	// PollR2RW is used to monitor writable for FDOperator,
+	// PollR2W is used to monitor writable for FDOperator,
 	// which is only called when the socket write buffer is full.
-	PollR2RW PollEvent = 0x5
+	PollR2W PollEvent = 0x5
 
-	// PollRW2R is used to remove the writable monitor of FDOperator, generally used with PollR2RW.
-	PollRW2R PollEvent = 0x6
+	// PollW2R is used to remove the writable monitor of FDOperator, generally used with PollR2W.
+	PollW2R PollEvent = 0x6
 )

--- a/poll_default_bsd.go
+++ b/poll_default_bsd.go
@@ -148,9 +148,9 @@ func (p *defaultPoll) Control(operator *FDOperator, event PollEvent) error {
 	case PollWritable:
 		operator.inuse()
 		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_ADD|syscall.EV_ENABLE|syscall.EV_ONESHOT
-	case PollR2RW:
+	case PollR2W:
 		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_ADD|syscall.EV_ENABLE
-	case PollRW2R:
+	case PollW2R:
 		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_DELETE|syscall.EV_ONESHOT
 	}
 	_, err := syscall.Kevent(p.fd, evs, nil, nil)

--- a/poll_default_bsd.go
+++ b/poll_default_bsd.go
@@ -103,23 +103,7 @@ func (p *defaultPoll) Wait() error {
 					hups = append(hups, operator)
 				}
 			case events[i].Filter == syscall.EVFILT_WRITE && events[i].Flags&syscall.EV_ENABLE != 0:
-				// for non-connection
-				if operator.OnWrite != nil {
-					operator.OnWrite(p)
-					break
-				}
-				// only for connection
-				var bs, supportZeroCopy = operator.Outputs(barriers[i].bs)
-				if len(bs) == 0 {
-					break
-				}
-				// TODO: Let the upper layer pass in whether to use ZeroCopy.
-				var n, err = sendmsg(operator.FD, bs, barriers[i].ivs, false && supportZeroCopy)
-				operator.OutputAck(n)
-				if err != nil && err != syscall.EAGAIN {
-					log.Printf("sendmsg(fd=%d) failed: %s", operator.FD, err.Error())
-					hups = append(hups, operator)
-				}
+				operator.OnWrite(p)
 			}
 			operator.done()
 		}

--- a/poll_default_linux.go
+++ b/poll_default_linux.go
@@ -197,9 +197,9 @@ func (p *defaultPoll) Control(operator *FDOperator, event PollEvent) error {
 	case PollWritable:
 		operator.inuse()
 		op, evt.events = syscall.EPOLL_CTL_ADD, EPOLLET|syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
-	case PollR2RW:
-		op, evt.events = syscall.EPOLL_CTL_MOD, EPOLLET|syscall.EPOLLIN|syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
-	case PollRW2R:
+	case PollR2W:
+		op, evt.events = syscall.EPOLL_CTL_MOD, EPOLLET|syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
+	case PollW2R:
 		op, evt.events = syscall.EPOLL_CTL_MOD, syscall.EPOLLIN|syscall.EPOLLRDHUP|syscall.EPOLLERR
 	}
 	return EpollCtl(p.fd, op, operator.FD, &evt)

--- a/poll_manager.go
+++ b/poll_manager.go
@@ -31,10 +31,22 @@ func setLoadBalance(lb LoadBalance) error {
 var pollmanager *manager
 
 func init() {
-	var loops = runtime.GOMAXPROCS(0)/20 + 1
 	pollmanager = &manager{}
 	pollmanager.SetLoadBalance(RoundRobin)
-	pollmanager.SetNumLoops(loops)
+	pollmanager.SetNumLoops(defaultNumLoops())
+}
+
+func defaultNumLoops() int {
+	procs := runtime.GOMAXPROCS(0)
+	loops := 1
+	// Loops produce events that handlers consume,
+	// so the producer should be faster than consumer otherwise it will have a bottleneck.
+	// But there is no universal option that could be appropriate for any use cases,
+	// plz use `SetNumLoops` if you do know what you want.
+	if procs > 4 {
+		loops = procs
+	}
+	return loops
 }
 
 // LoadBalance is used to do load balancing among multiple pollers.

--- a/poll_race_bsd.go
+++ b/poll_race_bsd.go
@@ -109,22 +109,7 @@ func (p *defaultPoll) Wait() error {
 					hups = append(hups, operator)
 				}
 			case events[i].Filter == syscall.EVFILT_WRITE && events[i].Flags&syscall.EV_ENABLE != 0:
-				// for non-connection
-				if operator.OnWrite != nil {
-					operator.OnWrite(p)
-					break
-				}
-				// only for connection
-				var bs, supportZeroCopy = operator.Outputs(barriers[i].bs)
-				if len(bs) == 0 {
-					break
-				}
-				// TODO: Let the upper layer pass in whether to use ZeroCopy.
-				var n, err = sendmsg(operator.FD, bs, barriers[i].ivs, false && supportZeroCopy)
-				operator.OutputAck(n)
-				if err != nil && err != syscall.EAGAIN {
-					hups = append(hups, operator)
-				}
+				operator.OnWrite(p)
 			}
 			operator.done()
 		}

--- a/poll_race_bsd.go
+++ b/poll_race_bsd.go
@@ -164,9 +164,9 @@ func (p *defaultPoll) Control(operator *FDOperator, event PollEvent) error {
 		operator.inuse()
 		p.m.Store(operator.FD, operator)
 		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_ADD|syscall.EV_ENABLE|syscall.EV_ONESHOT
-	case PollR2RW:
+	case PollR2W:
 		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_ADD|syscall.EV_ENABLE
-	case PollRW2R:
+	case PollW2R:
 		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_DELETE|syscall.EV_ONESHOT
 	}
 	_, err := syscall.Kevent(p.fd, evs, nil, nil)

--- a/poll_race_linux.go
+++ b/poll_race_linux.go
@@ -206,9 +206,9 @@ func (p *defaultPoll) Control(operator *FDOperator, event PollEvent) error {
 		operator.inuse()
 		p.m.Store(operator.FD, operator)
 		op, evt.Events = syscall.EPOLL_CTL_ADD, EPOLLET|syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
-	case PollR2RW:
-		op, evt.Events = syscall.EPOLL_CTL_MOD, EPOLLET|syscall.EPOLLIN|syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
-	case PollRW2R:
+	case PollR2W:
+		op, evt.Events = syscall.EPOLL_CTL_MOD, EPOLLET|syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
+	case PollW2R:
 		op, evt.Events = syscall.EPOLL_CTL_MOD, syscall.EPOLLIN|syscall.EPOLLRDHUP|syscall.EPOLLERR
 	}
 	return syscall.EpollCtl(p.fd, op, operator.FD, &evt)

--- a/poll_test.go
+++ b/poll_test.go
@@ -84,7 +84,7 @@ func TestPollMod(t *testing.T) {
 	r, w, h = atomic.LoadInt32(&rn), atomic.LoadInt32(&wn), atomic.LoadInt32(&hn)
 	Assert(t, r == 0 && w == 1 && h == 0, r, w, h)
 
-	err = p.Control(rop, PollR2RW) // trigger write
+	err = p.Control(rop, PollR2W) // trigger write
 	MustNil(t, err)
 	time.Sleep(time.Millisecond)
 	r, w, h = atomic.LoadInt32(&rn), atomic.LoadInt32(&wn), atomic.LoadInt32(&hn)
@@ -125,6 +125,6 @@ func BenchmarkPollMod(b *testing.B) {
 	b.ReportAllocs()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		p.Control(operator, PollR2RW)
+		p.Control(operator, PollR2W)
 	}
 }


### PR DESCRIPTION
- Close connection gracefully:
  - **conn used by client**: closeCallback should wait for `Flush` && `Outputs` finished.
  - **conn used by server**: closeCallback should wait for `onRequest` processed if is processing.
- Flush should do the syscall by itself and poller only promise to wake up writer trigger.