### PR TITLE
feat:add suport net protocol enums

### DIFF
--- a/net_types.go
+++ b/net_types.go
@@ -1,0 +1,24 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file may have been modified by CloudWeGo authors. (“CloudWeGo Modifications”).
+// All CloudWeGo Modifications are Copyright 2021 CloudWeGo authors.
+
+package netpoll
+// suport portocol tcp, tcp4, tcp6, udp, udp4, udp6, unix
+const(
+	TCP="tcp"
+
+	TCP4="tcp3"
+
+	TCP6="tcp6"
+
+	UDP="udp"
+
+	UDP4="udp4"
+
+	UDP6="udp6"
+
+	UNIX="unix"
+)


### PR DESCRIPTION
When I Use netpoll to create server eventloop or dial client,it`s unfriendly to write net types by hand.Such as ,"tcp" or "udp",I think a enums is need.