### PR TITLE
reduce idle wake-ups

### DIFF
--- a/connection_reactor.go
+++ b/connection_reactor.go
@@ -90,7 +90,9 @@ func (c *connection) inputAck(n int) (err error) {
 	}
 	leftover := atomic.AddInt32(&c.waitReadSize, int32(-n))
 	err = c.inputBuffer.BookAck(n, leftover <= 0)
-	c.triggerRead()
+	if leftover <= 0 {
+		c.triggerRead()
+	}
 	c.onRequest()
 	return err
 }


### PR DESCRIPTION
since the original goroutine will just go into sleep again if the inputBuffer is not enough, there is no need to trigger it unless `waitReadSize` was 0