### PR TITLE
feat: use accept4 and socket syscall with options

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -10,6 +10,10 @@ header:
   paths-ignore:
     - 'net_netfd.go'
     - 'net_sock.go'
+    - 'net_sock_bsd.go'
+    - 'net_sock_linux.go'
+    - 'sys_exec_bsd.go'
+    - 'sys_exec_linux.go'
     - 'net_tcpsock.go'
     - 'net_unixsock.go'
     - 'sys_sockopt_bsd.go'

--- a/connection_test.go
+++ b/connection_test.go
@@ -46,7 +46,7 @@ func TestConnectionWrite(t *testing.T) {
 		return context.Background()
 	}
 
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	var rconn, wconn = &connection{}, &connection{}
 	rconn.init(&netFD{fd: r}, prepare)
 	wconn.init(&netFD{fd: w}, prepare)
@@ -62,7 +62,7 @@ func TestConnectionWrite(t *testing.T) {
 }
 
 func TestConnectionRead(t *testing.T) {
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	var rconn, wconn = &connection{}, &connection{}
 	rconn.init(&netFD{fd: r}, nil)
 	wconn.init(&netFD{fd: w}, nil)
@@ -93,7 +93,7 @@ func TestConnectionRead(t *testing.T) {
 }
 
 func TestConnectionReadAfterClosed(t *testing.T) {
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	var rconn = &connection{}
 	rconn.init(&netFD{fd: r}, nil)
 	var size = 256
@@ -113,7 +113,7 @@ func TestConnectionReadAfterClosed(t *testing.T) {
 }
 
 func TestConnectionWaitReadHalfPacket(t *testing.T) {
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	var rconn = &connection{}
 	rconn.init(&netFD{fd: r}, nil)
 	var size = pagesize * 2
@@ -233,7 +233,7 @@ func TestConnectionLargeMemory(t *testing.T) {
 	runtime.GC()
 	runtime.ReadMemStats(&start)
 
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	var rconn = &connection{}
 	rconn.init(&netFD{fd: r}, nil)
 

--- a/net_listener.go
+++ b/net_listener.go
@@ -96,13 +96,14 @@ func (ln *listener) Accept() (net.Conn, error) {
 		return ln.UDPAccept()
 	}
 	// tcp
-	var fd, sa, err = syscall.Accept(ln.fd)
+	var fd, sa, err = accept(ln.fd)
 	if err != nil {
 		if err == syscall.EAGAIN {
 			return nil, nil
 		}
 		return nil, err
 	}
+
 	var nfd = &netFD{}
 	nfd.fd = fd
 	nfd.localAddr = ln.addr

--- a/net_sock_bsd.go
+++ b/net_sock_bsd.go
@@ -1,0 +1,26 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file may have been modified by CloudWeGo authors. (“CloudWeGo Modifications”).
+// All CloudWeGo Modifications are Copyright 2021 CloudWeGo authors.
+
+// +build darwin netbsd freebsd openbsd dragonfly
+
+package netpoll
+
+import "syscall"
+
+// Wrapper around the accept system call that marks the returned file
+// descriptor as nonblocking.
+func accept(s int) (int, syscall.Sockaddr, error) {
+	ns, sa, err := syscall.Accept(s)
+	if err != nil {
+		return -1, nil, err
+	}
+	if err = syscall.SetNonblock(ns, true); err != nil {
+		syscall.Close(ns)
+		return -1, nil, err
+	}
+	return ns, sa, nil
+}

--- a/net_sock_linux.go
+++ b/net_sock_linux.go
@@ -1,0 +1,40 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file may have been modified by CloudWeGo authors. (“CloudWeGo Modifications”).
+// All CloudWeGo Modifications are Copyright 2021 CloudWeGo authors.
+
+package netpoll
+
+import "syscall"
+
+// Wrapper around the accept system call that marks the returned file
+// descriptor as nonblocking.
+func accept(s int) (int, syscall.Sockaddr, error) {
+	ns, sa, err := syscall.Accept4(s, syscall.SOCK_NONBLOCK)
+	// On Linux the accept4 system call was introduced in 2.6.28
+	// kernel and on FreeBSD it was introduced in 10 kernel. If we
+	// get an ENOSYS error on both Linux and FreeBSD, or EINVAL
+	// error on Linux, fall back to using accept.
+	switch err {
+	case nil:
+		return ns, sa, nil
+	default: // errors other than the ones listed
+		return -1, sa, err
+	case syscall.ENOSYS: // syscall missing
+	case syscall.EINVAL: // some Linux use this instead of ENOSYS
+	case syscall.EACCES: // some Linux use this instead of ENOSYS
+	case syscall.EFAULT: // some Linux use this instead of ENOSYS
+	}
+
+	ns, sa, err = syscall.Accept(s)
+	if err != nil {
+		return -1, nil, err
+	}
+	if err = syscall.SetNonblock(ns, true); err != nil {
+		syscall.Close(ns)
+		return -1, nil, err
+	}
+	return ns, sa, nil
+}

--- a/netpoll_options.go
+++ b/netpoll_options.go
@@ -65,6 +65,13 @@ func WithIdleTimeout(timeout time.Duration) Option {
 	}}
 }
 
+// WithDeferAccept sets the switch of TCP_DEFER_ACCEPT
+func WithDeferAccept(d bool) Option {
+	return Option{func(op *options) {
+		op.deferAccept = d
+	}}
+}
+
 // Option .
 type Option struct {
 	f func(*options)
@@ -74,6 +81,7 @@ type options struct {
 	onPrepare   OnPrepare
 	readTimeout time.Duration
 	idleTimeout time.Duration
+	deferAccept bool
 }
 
 func (opt *options) prepare(onRequest OnRequest) OnPrepare {

--- a/poll_manager_test.go
+++ b/poll_manager_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestPollManager(t *testing.T) {
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	var rconn, wconn = &connection{}, &connection{}
 	rconn.init(&netFD{fd: r}, nil)
 	wconn.init(&netFD{fd: w}, nil)

--- a/poll_test.go
+++ b/poll_test.go
@@ -66,7 +66,7 @@ func TestPollMod(t *testing.T) {
 		stop <- p.Wait()
 	}()
 
-	var rfd, wfd = GetSysFdPairs()
+	var rfd, wfd = getSysFdPairs()
 	var rop = &FDOperator{FD: rfd, OnRead: read, OnWrite: write, OnHup: hup}
 	var wop = &FDOperator{FD: wfd, OnRead: read, OnWrite: write, OnHup: hup}
 	var err error
@@ -117,7 +117,7 @@ func TestPollClose(t *testing.T) {
 func BenchmarkPollMod(b *testing.B) {
 	b.StopTimer()
 	var p = openDefaultPoll()
-	r, _ := GetSysFdPairs()
+	r, _ := getSysFdPairs()
 	var operator = &FDOperator{FD: r}
 	p.Control(operator, PollReadable)
 

--- a/sys_exec_bsd.go
+++ b/sys_exec_bsd.go
@@ -41,3 +41,7 @@ func getSysFdPairs() (r, w int) {
 	syscall.SetNonblock(fds[1], true)
 	return fds[0], fds[1]
 }
+
+func setTCPDeferAccept(fd int, b bool) (err error) {
+	return nil
+}

--- a/sys_exec_bsd.go
+++ b/sys_exec_bsd.go
@@ -1,0 +1,43 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file may have been modified by CloudWeGo authors. (“CloudWeGo Modifications”).
+// All CloudWeGo Modifications are Copyright 2021 CloudWeGo authors.
+
+// +build aix darwin nacl solaris
+
+package netpoll
+
+import (
+	"os"
+	"syscall"
+)
+
+// Wrapper around the socket system call that marks the returned file
+// descriptor as nonblocking and close-on-exec.
+func sysSocket(family, sotype, proto int) (int, error) {
+	// See ../syscall/exec_unix.go for description of ForkLock.
+	syscall.ForkLock.RLock()
+	s, err := syscall.Socket(family, sotype, proto)
+	if err == nil {
+		syscall.CloseOnExec(s)
+	}
+	syscall.ForkLock.RUnlock()
+	if err != nil {
+		return -1, os.NewSyscallError("socket", err)
+	}
+	if err = syscall.SetNonblock(s, true); err != nil {
+		syscall.Close(s)
+		return -1, os.NewSyscallError("setnonblock", err)
+	}
+	return s, nil
+}
+
+// getSysFdPairs creates and returns the fds of a pair of non-blocking sockets.
+func getSysFdPairs() (r, w int) {
+	fds, _ := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	syscall.SetNonblock(fds[0], true)
+	syscall.SetNonblock(fds[1], true)
+	return fds[0], fds[1]
+}

--- a/sys_exec_linux.go
+++ b/sys_exec_linux.go
@@ -51,3 +51,7 @@ func getSysFdPairs() (r, w int) {
 	fds, _ := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM|syscall.SOCK_NONBLOCK, 0)
 	return fds[0], fds[1]
 }
+
+func setTCPDeferAccept(fd int, b bool) (err error) {
+	return syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_DEFER_ACCEPT, boolint(b))
+}

--- a/sys_exec_linux.go
+++ b/sys_exec_linux.go
@@ -1,0 +1,53 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file may have been modified by CloudWeGo authors. (“CloudWeGo Modifications”).
+// All CloudWeGo Modifications are Copyright 2021 CloudWeGo authors.
+
+package netpoll
+
+import (
+	"os"
+	"syscall"
+)
+
+// Wrapper around the socket system call that marks the returned file
+// descriptor as nonblocking and close-on-exec.
+func sysSocket(family, sotype, proto int) (int, error) {
+	s, err := syscall.Socket(family, sotype|syscall.SOCK_NONBLOCK|syscall.SOCK_CLOEXEC, proto)
+	// On Linux the SOCK_NONBLOCK and SOCK_CLOEXEC flags were
+	// introduced in 2.6.27 kernel and on FreeBSD both flags were
+	// introduced in 10 kernel. If we get an EINVAL error on Linux
+	// or EPROTONOSUPPORT error on FreeBSD, fall back to using
+	// socket without them.
+	switch err {
+	case nil:
+		return s, nil
+	default:
+		return -1, os.NewSyscallError("socket", err)
+	case syscall.EPROTONOSUPPORT, syscall.EINVAL:
+	}
+
+	// See ../syscall/exec_unix.go for description of ForkLock.
+	syscall.ForkLock.RLock()
+	s, err = syscall.Socket(family, sotype, proto)
+	if err == nil {
+		syscall.CloseOnExec(s)
+	}
+	syscall.ForkLock.RUnlock()
+	if err != nil {
+		return -1, os.NewSyscallError("socket", err)
+	}
+	if err = syscall.SetNonblock(s, true); err != nil {
+		syscall.Close(s)
+		return -1, os.NewSyscallError("setnonblock", err)
+	}
+	return s, nil
+}
+
+// getSysFdPairs creates and returns the fds of a pair of sockets.
+func getSysFdPairs() (r, w int) {
+	fds, _ := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM|syscall.SOCK_NONBLOCK, 0)
+	return fds[0], fds[1]
+}

--- a/sys_exec_test.go
+++ b/sys_exec_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestWritev(t *testing.T) {
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	var barrier = barrier{}
 	barrier.bs = [][]byte{
 		[]byte(""),            // len=0
@@ -40,7 +40,7 @@ func TestWritev(t *testing.T) {
 }
 
 func TestReadv(t *testing.T) {
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	vs := [][]byte{
 		[]byte("first line"),  // len=10
 		[]byte("second line"), // len=11
@@ -68,7 +68,7 @@ func TestReadv(t *testing.T) {
 }
 
 func TestSendmsg(t *testing.T) {
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	var barrier = barrier{}
 	barrier.bs = [][]byte{
 		[]byte(""),            // len=0
@@ -89,7 +89,7 @@ func TestSendmsg(t *testing.T) {
 
 func BenchmarkWrite(b *testing.B) {
 	b.StopTimer()
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	message := "hello, world!"
 	size := 5
 
@@ -116,7 +116,7 @@ func BenchmarkWrite(b *testing.B) {
 
 func BenchmarkWritev(b *testing.B) {
 	b.StopTimer()
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	message := "hello, world!"
 	size := 5
 	var barrier = barrier{}
@@ -144,7 +144,7 @@ func BenchmarkWritev(b *testing.B) {
 
 func BenchmarkSendmsg(b *testing.B) {
 	b.StopTimer()
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	message := "hello, world!"
 	size := 5
 	var barrier = barrier{}
@@ -172,7 +172,7 @@ func BenchmarkSendmsg(b *testing.B) {
 
 func BenchmarkRead(b *testing.B) {
 	b.StopTimer()
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	message := "hello, world!"
 	size := 5
 	wmsg := make([]byte, size*len(message))
@@ -199,7 +199,7 @@ func BenchmarkRead(b *testing.B) {
 
 func BenchmarkReadv(b *testing.B) {
 	b.StopTimer()
-	r, w := GetSysFdPairs()
+	r, w := getSysFdPairs()
 	message := "hello, world!"
 	size := 5
 	var barrier = barrier{}


### PR DESCRIPTION
- `accept4` and `socket` 系统调用都允许直接指定 socket type，这样后续可以减少一次设置 nonblocking 的系统调用开销。
- [TCP_DEFER_ACCEPT](https://man7.org/linux/man-pages/man7/tcp.7.html): "Allow a listener to be awakened only when data arrives on the socket." 对于 RPC 请求来说，连接后必然会伴随着一个后续请求，如果 accept 只在有数据进来时被唤醒，可以让 poller 在一次调度时，处理完了 connect 后立刻去处理读取。