### PR TITLE
feat: new conn api - Until

### DIFF
--- a/connection_impl.go
+++ b/connection_impl.go
@@ -137,8 +137,8 @@ func (c *connection) Len() (length int) {
 	return c.inputBuffer.Len()
 }
 
-// ReadSlice implements Connection.
-func (c *connection) ReadSlice(delim byte) (line []byte, err error) {
+// Until implements Connection.
+func (c *connection) Until(delim byte) (line []byte, err error) {
 	var n, l int
 	for {
 		if err = c.waitRead(n + 1); err != nil {

--- a/connection_impl.go
+++ b/connection_impl.go
@@ -142,8 +142,11 @@ func (c *connection) Until(delim byte) (line []byte, err error) {
 	var n, l int
 	for {
 		if err = c.waitRead(n + 1); err != nil {
+			// return all the data in the buffer
+			line, _ = c.inputBuffer.Next(c.inputBuffer.Len())
 			return
 		}
+
 		l = c.inputBuffer.Len()
 		i := c.inputBuffer.indexByte(delim, n)
 		if i < 0 {

--- a/connection_impl.go
+++ b/connection_impl.go
@@ -137,6 +137,23 @@ func (c *connection) Len() (length int) {
 	return c.inputBuffer.Len()
 }
 
+// ReadSlice implements Connection.
+func (c *connection) ReadSlice(delim byte) (line []byte, err error) {
+	var n, l int
+	for {
+		if err = c.waitRead(n + 1); err != nil {
+			return
+		}
+		l = c.Reader().Len()
+		i := c.inputBuffer.indexByte(delim, n)
+		if i < 0 {
+			n = l
+			continue
+		}
+		return c.Next(i + 1)
+	}
+}
+
 // ReadString implements Connection.
 func (c *connection) ReadString(n int) (s string, err error) {
 	if err = c.waitRead(n); err != nil {

--- a/connection_impl.go
+++ b/connection_impl.go
@@ -144,10 +144,10 @@ func (c *connection) Until(delim byte) (line []byte, err error) {
 		if err = c.waitRead(n + 1); err != nil {
 			return
 		}
-		l = c.Reader().Len()
+		l = c.inputBuffer.Len()
 		i := c.inputBuffer.indexByte(delim, n)
 		if i < 0 {
-			n = l
+			n = l //skip all exists bytes
 			continue
 		}
 		return c.Next(i + 1)

--- a/connection_test.go
+++ b/connection_test.go
@@ -282,7 +282,7 @@ func TestSetTCPNoDelay(t *testing.T) {
 	MustTrue(t, n == 0)
 }
 
-func TestConnectionReadSlice(t *testing.T) {
+func TestConnectionUntil(t *testing.T) {
 	r, w := GetSysFdPairs()
 	var rconn, wconn = &connection{}, &connection{}
 	rconn.init(&netFD{fd: r}, nil)
@@ -304,7 +304,7 @@ func TestConnectionReadSlice(t *testing.T) {
 	}()
 
 	for i := 0; i < 100000; i++ {
-		buf, err := rconn.Reader().ReadSlice('\n')
+		buf, err := rconn.Reader().Until('\n')
 		if err != nil && errors.Is(err, ErrConnClosed) || !rconn.IsActive() {
 			return
 		}

--- a/connection_test.go
+++ b/connection_test.go
@@ -297,6 +297,7 @@ func TestConnectionUntil(t *testing.T) {
 			MustNil(t, err)
 			MustTrue(t, n == len(msg))
 		}
+		wconn.Write(msg[:100])
 		wconn.Close()
 	}()
 
@@ -307,6 +308,7 @@ func TestConnectionUntil(t *testing.T) {
 		rconn.Reader().Release()
 	}
 
-	_, err := rconn.Reader().Until('\n')
+	buf, err := rconn.Reader().Until('\n')
+	Equal(t, len(buf), 100)
 	MustTrue(t, errors.Is(err, ErrEOF))
 }

--- a/nocopy.go
+++ b/nocopy.go
@@ -73,13 +73,13 @@ type Reader interface {
 	//
 	ReadByte() (b byte, err error)
 
-	// ReadSlice reads until the first occurrence of delim in the input,
+	// Until reads until the first occurrence of delim in the input,
 	// returning a slice pointing at the bytes in the input buffer.
 	// The bytes stop being valid at the next read.
-	// If ReadSlice encounters an error before finding a delimiter,
+	// If Until encounters an error before finding a delimiter,
 	// it returns all the data in the buffer and the error itself (often io.EOF).
-	// ReadSlice returns err != nil if and only if line does not end in delim.
-	ReadSlice(delim byte) (line []byte, err error)
+	// Until returns err != nil only if line does not end in delim.
+	Until(delim byte) (line []byte, err error)
 
 	// Slice returns a new Reader containing the next n bytes from this reader,
 	// the operation is zero-copy, similar to b = p [:n].

--- a/nocopy.go
+++ b/nocopy.go
@@ -46,6 +46,13 @@ type Reader interface {
 	// a faster implementation of Next when the next data is not used.
 	Skip(n int) (err error)
 
+	// Until reads until the first occurrence of delim in the input,
+	// returning a slice stops with delim in the input buffer.
+	// If Until encounters an error before finding a delimiter,
+	// it returns all the data in the buffer and the error itself (often ErrEOF or ErrConnClosed).
+	// Until returns err != nil only if line does not end in delim.
+	Until(delim byte) (line []byte, err error)
+
 	// ReadString is a faster implementation of Next when a string needs to be returned.
 	// It replaces:
 	//
@@ -72,14 +79,6 @@ type Reader interface {
 	//  return p[0], err
 	//
 	ReadByte() (b byte, err error)
-
-	// Until reads until the first occurrence of delim in the input,
-	// returning a slice pointing at the bytes in the input buffer.
-	// The bytes stop being valid at the next read.
-	// If Until encounters an error before finding a delimiter,
-	// it returns all the data in the buffer and the error itself (often io.EOF).
-	// Until returns err != nil only if line does not end in delim.
-	Until(delim byte) (line []byte, err error)
 
 	// Slice returns a new Reader containing the next n bytes from this reader,
 	// the operation is zero-copy, similar to b = p [:n].

--- a/nocopy.go
+++ b/nocopy.go
@@ -73,6 +73,14 @@ type Reader interface {
 	//
 	ReadByte() (b byte, err error)
 
+	// ReadSlice reads until the first occurrence of delim in the input,
+	// returning a slice pointing at the bytes in the input buffer.
+	// The bytes stop being valid at the next read.
+	// If ReadSlice encounters an error before finding a delimiter,
+	// it returns all the data in the buffer and the error itself (often io.EOF).
+	// ReadSlice returns err != nil if and only if line does not end in delim.
+	ReadSlice(delim byte) (line []byte, err error)
+
 	// Slice returns a new Reader containing the next n bytes from this reader,
 	// the operation is zero-copy, similar to b = p [:n].
 	Slice(n int) (r Reader, err error)

--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -18,6 +18,7 @@
 package netpoll
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"reflect"
@@ -258,6 +259,15 @@ func (b *LinkBuffer) ReadByte() (p byte, err error) {
 		}
 		b.read = b.read.next
 	}
+}
+
+// ReadSlice returns a slice ends with the delim in the buffer.
+func (b *LinkBuffer) ReadSlice(delim byte) (line []byte, err error) {
+	n := b.indexByte(delim, 0)
+	if n < 0 {
+		return nil, fmt.Errorf("link buffer read slice cannot find: '%b'", delim)
+	}
+	return b.readBinary(n + 1), nil
 }
 
 // Slice returns a new LinkBuffer, which is a zero-copy slice of this LinkBuffer,
@@ -597,6 +607,32 @@ func (b *LinkBuffer) calcMaxSize() (sum int) {
 	}
 	sum += len(b.read.buf)
 	return sum
+}
+
+// indexByte returns the index of the first instance of c in b, or -1 if c is not present in b.
+func (b *LinkBuffer) indexByte(c byte, skip int) int {
+	var n, l, pos int
+	for node := b.read; node != nil; node = node.next {
+		l = node.Len()
+		pos = node.off
+		if l <= skip {
+			skip -= l
+			n += l
+			continue
+		} else if skip > 0 {
+			pos += skip
+			skip = 0
+		}
+
+		i := bytes.IndexByte(node.buf[pos:], c)
+		if i < 0 {
+			n += l
+			continue
+		}
+		n += pos - node.off + i
+		return n
+	}
+	return -1
 }
 
 // resetTail will reset tail node or add an empty tail node to

--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -261,8 +261,8 @@ func (b *LinkBuffer) ReadByte() (p byte, err error) {
 	}
 }
 
-// ReadSlice returns a slice ends with the delim in the buffer.
-func (b *LinkBuffer) ReadSlice(delim byte) (line []byte, err error) {
+// Until returns a slice ends with the delim in the buffer.
+func (b *LinkBuffer) Until(delim byte) (line []byte, err error) {
 	n := b.indexByte(delim, 0)
 	if n < 0 {
 		return nil, fmt.Errorf("link buffer read slice cannot find: '%b'", delim)

--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -267,7 +267,7 @@ func (b *LinkBuffer) Until(delim byte) (line []byte, err error) {
 	if n < 0 {
 		return nil, fmt.Errorf("link buffer read slice cannot find: '%b'", delim)
 	}
-	return b.readBinary(n + 1), nil
+	return b.Next(n + 1)
 }
 
 // Slice returns a new LinkBuffer, which is a zero-copy slice of this LinkBuffer,
@@ -609,28 +609,34 @@ func (b *LinkBuffer) calcMaxSize() (sum int) {
 	return sum
 }
 
-// indexByte returns the index of the first instance of c in b, or -1 if c is not present in b.
+// indexByte returns the index of the first instance of c in buffer, or -1 if c is not present in buffer.
 func (b *LinkBuffer) indexByte(c byte, skip int) int {
-	var n, l, pos int
-	for node := b.read; node != nil; node = node.next {
+	size := b.Len()
+	if skip >= size {
+		return -1
+	}
+	var unread, n, l int
+	node := b.read
+	for unread = size; unread > 0; unread -= n {
 		l = node.Len()
-		pos = node.off
-		if l <= skip {
-			skip -= l
-			n += l
-			continue
-		} else if skip > 0 {
-			pos += skip
-			skip = 0
+		if l >= unread { // last node
+			n = unread
+		} else { // read full node
+			n = l
 		}
 
-		i := bytes.IndexByte(node.buf[pos:], c)
-		if i < 0 {
-			n += l
+		// skip current node
+		if skip >= n {
+			skip -= n
+			node = node.next
 			continue
 		}
-		n += pos - node.off + i
-		return n
+		i := bytes.IndexByte(node.Peek(n)[skip:], c)
+		if i >= 0 {
+			return (size - unread) + skip + i // past_read + skip_read + index
+		}
+		skip = 0 // no skip bytes
+		node = node.next
 	}
 	return -1
 }

--- a/nocopy_linkbuffer_race.go
+++ b/nocopy_linkbuffer_race.go
@@ -183,6 +183,17 @@ func (b *LinkBuffer) Skip(n int) (err error) {
 	return nil
 }
 
+// Until returns a slice ends with the delim in the buffer.
+func (b *LinkBuffer) Until(delim byte) (line []byte, err error) {
+	b.Lock()
+	defer b.Unlock()
+	n := b.indexByte(delim, 0)
+	if n < 0 {
+		return nil, fmt.Errorf("link buffer cannot find delim: '%b'", delim)
+	}
+	return b.Next(n + 1)
+}
+
 // Release the node that has been read.
 // b.flush == nil indicates that this LinkBuffer is created by LinkBuffer.Slice
 func (b *LinkBuffer) Release() (err error) {
@@ -278,15 +289,6 @@ func (b *LinkBuffer) ReadByte() (p byte, err error) {
 		}
 		b.read = b.read.next
 	}
-}
-
-// Until returns a slice ends with the delim in the buffer.
-func (b *LinkBuffer) Until(delim byte) (line []byte, err error) {
-	n := b.indexByte(delim, 0)
-	if n < 0 {
-		return nil, fmt.Errorf("link buffer cannot find delim: '%b'", delim)
-	}
-	return b.Next(n + 1), nil
 }
 
 // Slice returns a new LinkBuffer, which is a zero-copy slice of this LinkBuffer,

--- a/nocopy_linkbuffer_race.go
+++ b/nocopy_linkbuffer_race.go
@@ -280,11 +280,11 @@ func (b *LinkBuffer) ReadByte() (p byte, err error) {
 	}
 }
 
-// ReadSlice returns a slice ends with the delim in the buffer.
-func (b *LinkBuffer) ReadSlice(delim byte) (line []byte, err error) {
+// Until returns a slice ends with the delim in the buffer.
+func (b *LinkBuffer) Until(delim byte) (line []byte, err error) {
 	n := b.indexByte(delim, 0)
 	if n < 0 {
-		return nil, fmt.Errorf("link buffer read slice cannot find: '%b'", delim)
+		return nil, fmt.Errorf("link buffer cannot find delim: '%b'", delim)
 	}
 	return b.readBinary(n + 1), nil
 }

--- a/nocopy_linkbuffer_test.go
+++ b/nocopy_linkbuffer_test.go
@@ -458,6 +458,25 @@ func TestUnsafeStringToSlice(t *testing.T) {
 	Equal(t, string(bs), "hello world")
 }
 
+func TestLinkBufferIndexByte(t *testing.T) {
+	// clean & new
+	LinkBufferCap = 128
+
+	lb := NewLinkBuffer()
+	buf, err := lb.Malloc(1002)
+	buf[500] = '\n'
+	buf[1001] = '\n'
+	MustNil(t, err)
+	lb.Flush()
+
+	n := lb.indexByte('\n', 0)
+	Equal(t, n, 500)
+	n = lb.indexByte('\n', 500)
+	Equal(t, n, 500)
+	n = lb.indexByte('\n', 501)
+	Equal(t, n, 1001)
+}
+
 func BenchmarkStringToSliceByte(b *testing.B) {
 	b.StopTimer()
 	s := "hello world"

--- a/nocopy_readwriter.go
+++ b/nocopy_readwriter.go
@@ -102,6 +102,10 @@ func (r *zcReader) ReadByte() (b byte, err error) {
 	return r.buf.ReadByte()
 }
 
+func (r *zcReader) ReadSlice(delim byte) (line []byte, err error) {
+	return r.buf.ReadSlice(delim)
+}
+
 func (r *zcReader) waitRead(n int) (err error) {
 	for r.buf.Len() < n {
 		err = r.fill(n)

--- a/nocopy_readwriter.go
+++ b/nocopy_readwriter.go
@@ -102,8 +102,8 @@ func (r *zcReader) ReadByte() (b byte, err error) {
 	return r.buf.ReadByte()
 }
 
-func (r *zcReader) ReadSlice(delim byte) (line []byte, err error) {
-	return r.buf.ReadSlice(delim)
+func (r *zcReader) Until(delim byte) (line []byte, err error) {
+	return r.buf.Until(delim)
 }
 
 func (r *zcReader) waitRead(n int) (err error) {


### PR DESCRIPTION
用户态实现 readslice 性能损耗会更大，因为无法记忆上一次遍历的坐标且还需要把底层二维数组转成一维数组。每次需要重头遍历。