### PR TITLE
fix: FDOperator.reset() not reset op.OnWrite

### DIFF
--- a/fd_operator.go
+++ b/fd_operator.go
@@ -83,7 +83,7 @@ func (op *FDOperator) isUnused() bool {
 
 func (op *FDOperator) reset() {
 	op.FD = 0
-	op.OnRead, op.OnRead, op.OnHup = nil, nil, nil
+	op.OnRead, op.OnWrite, op.OnHup = nil, nil, nil
 	op.Inputs, op.InputAck = nil, nil
 	op.Outputs, op.OutputAck = nil, nil
 	op.poll = nil


### PR DESCRIPTION
op.OnWrite was wrongly written as op.OnRead