### PR TITLE
fix: dont check epollout when epollerr

### DIFF
--- a/poll_default_linux.go
+++ b/poll_default_linux.go
@@ -159,10 +159,11 @@ func (p *defaultPoll) handler(events []epollevent) (closed bool) {
 			// So here we need to check this error, if it is EAGAIN then do nothing, otherwise still mark as hup.
 			if _, _, _, _, err := syscall.Recvmsg(operator.FD, nil, nil, syscall.MSG_ERRQUEUE); err != syscall.EAGAIN {
 				p.appendHup(operator)
-				continue
+			} else {
+				operator.done()
 			}
+			continue
 		}
-
 		// check poll out
 		if evt&syscall.EPOLLOUT != 0 {
 			if operator.OnWrite != nil {

--- a/poll_race_linux.go
+++ b/poll_race_linux.go
@@ -156,8 +156,10 @@ func (p *defaultPoll) handler(events []syscall.EpollEvent) (closed bool) {
 			// So here we need to check this error, if it is EAGAIN then do nothing, otherwise still mark as hup.
 			if _, _, _, _, err := syscall.Recvmsg(operator.FD, nil, nil, syscall.MSG_ERRQUEUE); err != syscall.EAGAIN {
 				p.appendHup(operator)
-				continue
+			} else {
+				operator.done()
 			}
+			continue
 		}
 
 		// check poll out


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (en: English/zh: Chinese):

en: do not check EPOLLOUT when EPOLLERR
zh: 当 EPOLLERR 发生时，跳过检查 EPOLLOUT 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
