### PR TITLE
fix: close connection when readv syscall return 0, nil

### DIFF
--- a/connection_impl.go
+++ b/connection_impl.go
@@ -476,7 +476,7 @@ func (c *connection) fill(need int) (err error) {
 		if err != nil {
 			break
 		}
-		if n < 0 {
+		if n == 0 {
 			// we must reuse bs that has been booked, otherwise will mess the input buffer
 			goto TryRead
 		}

--- a/connection_reactor.go
+++ b/connection_reactor.go
@@ -19,7 +19,6 @@ package netpoll
 
 import (
 	"sync/atomic"
-	"syscall"
 )
 
 // ------------------------------------------ implement FDOperator ------------------------------------------
@@ -140,9 +139,9 @@ func (c *connection) flush() error {
 		return nil
 	}
 	// TODO: Let the upper layer pass in whether to use ZeroCopy.
-	var bs = c.outputBuffer.GetBytes(c.outputBarrier.bs)
-	var n, err = sendmsg(c.fd, bs, c.outputBarrier.ivs, false && c.supportZeroCopy)
-	if err != nil && err != syscall.EAGAIN {
+	bs := c.outputBuffer.GetBytes(c.outputBarrier.bs)
+	n, err := iosend(c.fd, bs, c.outputBarrier.ivs, false && c.supportZeroCopy)
+	if err != nil {
 		return Exception(err, "when flush")
 	}
 	if n > 0 {

--- a/net_io.go
+++ b/net_io.go
@@ -1,3 +1,17 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package netpoll
 
 import "syscall"

--- a/net_io.go
+++ b/net_io.go
@@ -1,0 +1,28 @@
+package netpoll
+
+import "syscall"
+
+// return value:
+// - n: n < 0 but err == nil, retry syscall
+// - err: if not nil, connection should be closed.
+func ioread(fd int, bs [][]byte, ivs []syscall.Iovec) (n int, err error) {
+	n, err = readv(fd, bs, ivs)
+	if n == 0 && err == nil { // means EOF
+		return -1, Exception(ErrEOF, "")
+	}
+	if err == syscall.EINTR || err == syscall.EAGAIN {
+		return -1, nil
+	}
+	return n, err
+}
+
+// return value:
+// - n: n < 0 but err == nil, retry syscall
+// - err: if not nil, connection should be closed.
+func iosend(fd int, bs [][]byte, ivs []syscall.Iovec, zerocopy bool) (n int, err error) {
+	n, err = sendmsg(fd, bs, ivs, zerocopy)
+	if err == syscall.EAGAIN {
+		return -1, nil
+	}
+	return n, err
+}

--- a/net_io.go
+++ b/net_io.go
@@ -3,26 +3,26 @@ package netpoll
 import "syscall"
 
 // return value:
-// - n: n < 0 but err == nil, retry syscall
+// - n: n == 0 but err == nil, retry syscall
 // - err: if not nil, connection should be closed.
 func ioread(fd int, bs [][]byte, ivs []syscall.Iovec) (n int, err error) {
 	n, err = readv(fd, bs, ivs)
 	if n == 0 && err == nil { // means EOF
-		return -1, Exception(ErrEOF, "")
+		return 0, Exception(ErrEOF, "")
 	}
 	if err == syscall.EINTR || err == syscall.EAGAIN {
-		return -1, nil
+		return 0, nil
 	}
 	return n, err
 }
 
 // return value:
-// - n: n < 0 but err == nil, retry syscall
+// - n: n == 0 but err == nil, retry syscall
 // - err: if not nil, connection should be closed.
 func iosend(fd int, bs [][]byte, ivs []syscall.Iovec, zerocopy bool) (n int, err error) {
 	n, err = sendmsg(fd, bs, ivs, zerocopy)
 	if err == syscall.EAGAIN {
-		return -1, nil
+		return 0, nil
 	}
 	return n, err
 }

--- a/poll_default_bsd.go
+++ b/poll_default_bsd.go
@@ -19,7 +19,6 @@
 package netpoll
 
 import (
-	"log"
 	"sync/atomic"
 	"syscall"
 	"unsafe"
@@ -93,10 +92,9 @@ func (p *defaultPoll) Wait() error {
 					// only for connection
 					var bs = operator.Inputs(barriers[i].bs)
 					if len(bs) > 0 {
-						var n, err = readv(operator.FD, bs, barriers[i].ivs)
+						var n, err = ioread(operator.FD, bs, barriers[i].ivs)
 						operator.InputAck(n)
-						if err != nil && err != syscall.EAGAIN && err != syscall.EINTR {
-							log.Printf("readv(fd=%d) failed: %s", operator.FD, err.Error())
+						if err != nil {
 							p.appendHup(operator)
 							continue
 						}
@@ -120,10 +118,9 @@ func (p *defaultPoll) Wait() error {
 					var bs, supportZeroCopy = operator.Outputs(barriers[i].bs)
 					if len(bs) > 0 {
 						// TODO: Let the upper layer pass in whether to use ZeroCopy.
-						var n, err = sendmsg(operator.FD, bs, barriers[i].ivs, false && supportZeroCopy)
+						var n, err = iosend(operator.FD, bs, barriers[i].ivs, false && supportZeroCopy)
 						operator.OutputAck(n)
-						if err != nil && err != syscall.EAGAIN {
-							log.Printf("sendmsg(fd=%d) failed: %s", operator.FD, err.Error())
+						if err != nil {
 							p.appendHup(operator)
 							continue
 						}

--- a/poll_default_linux.go
+++ b/poll_default_linux.go
@@ -18,7 +18,6 @@
 package netpoll
 
 import (
-	"log"
 	"runtime"
 	"sync/atomic"
 	"syscall"
@@ -138,10 +137,9 @@ func (p *defaultPoll) handler(events []epollevent) (closed bool) {
 				// for connection
 				var bs = operator.Inputs(p.barriers[i].bs)
 				if len(bs) > 0 {
-					var n, err = readv(operator.FD, bs, p.barriers[i].ivs)
+					var n, err = ioread(operator.FD, bs, p.barriers[i].ivs)
 					operator.InputAck(n)
-					if err != nil && err != syscall.EAGAIN && err != syscall.EINTR {
-						log.Printf("readv(fd=%d) failed: %s", operator.FD, err.Error())
+					if err != nil {
 						p.appendHup(operator)
 						continue
 					}
@@ -174,10 +172,9 @@ func (p *defaultPoll) handler(events []epollevent) (closed bool) {
 				var bs, supportZeroCopy = operator.Outputs(p.barriers[i].bs)
 				if len(bs) > 0 {
 					// TODO: Let the upper layer pass in whether to use ZeroCopy.
-					var n, err = sendmsg(operator.FD, bs, p.barriers[i].ivs, false && supportZeroCopy)
+					var n, err = iosend(operator.FD, bs, p.barriers[i].ivs, false && supportZeroCopy)
 					operator.OutputAck(n)
-					if err != nil && err != syscall.EAGAIN {
-						log.Printf("sendmsg(fd=%d) failed: %s", operator.FD, err.Error())
+					if err != nil {
 						p.appendHup(operator)
 						continue
 					}

--- a/poll_race_bsd.go
+++ b/poll_race_bsd.go
@@ -19,7 +19,6 @@
 package netpoll
 
 import (
-	"log"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -100,10 +99,9 @@ func (p *defaultPoll) Wait() error {
 					// only for connection
 					var bs = operator.Inputs(barriers[i].bs)
 					if len(bs) > 0 {
-						var n, err = readv(operator.FD, bs, barriers[i].ivs)
+						var n, err = ioread(operator.FD, bs, barriers[i].ivs)
 						operator.InputAck(n)
-						if err != nil && err != syscall.EAGAIN && err != syscall.EINTR {
-							log.Printf("readv(fd=%d) failed: %s", operator.FD, err.Error())
+						if err != nil {
 							p.appendHup(operator)
 							continue
 						}
@@ -127,10 +125,9 @@ func (p *defaultPoll) Wait() error {
 					var bs, supportZeroCopy = operator.Outputs(barriers[i].bs)
 					if len(bs) > 0 {
 						// TODO: Let the upper layer pass in whether to use ZeroCopy.
-						var n, err = sendmsg(operator.FD, bs, barriers[i].ivs, false && supportZeroCopy)
+						var n, err = iosend(operator.FD, bs, barriers[i].ivs, false && supportZeroCopy)
 						operator.OutputAck(n)
-						if err != nil && err != syscall.EAGAIN {
-							log.Printf("sendmsg(fd=%d) failed: %s", operator.FD, err.Error())
+						if err != nil {
 							p.appendHup(operator)
 							continue
 						}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: close connection when readv syscall return n==0, err==nil
zh: 当 readv 返回 (0, nil) 时，关闭连接

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
