### PR TITLE
fix: limit iovecs max to 2GB(2^31)

### DIFF
--- a/sys_exec.go
+++ b/sys_exec.go
@@ -18,6 +18,7 @@
 package netpoll
 
 import (
+	"math"
 	"os"
 	"syscall"
 	"unsafe"
@@ -95,15 +96,36 @@ func readv(fd int, bs [][]byte, ivs []syscall.Iovec) (n int, err error) {
 // TODO: read from sysconf(_SC_IOV_MAX)? The Linux default is
 //  1024 and this seems conservative enough for now. Darwin's
 //  UIO_MAXIOV also seems to be 1024.
+// iovecs limit length to 2GB(2^31)
 func iovecs(bs [][]byte, ivs []syscall.Iovec) (iovLen int) {
+	totalLen := 0
 	for i := 0; i < len(bs); i++ {
 		chunk := bs[i]
-		if len(chunk) == 0 {
+		l := len(chunk)
+		if l == 0 {
 			continue
 		}
 		ivs[iovLen].Base = &chunk[0]
-		ivs[iovLen].SetLen(len(chunk))
+		ivs[iovLen].SetLen(l)
+		totalLen += l
 		iovLen++
+	}
+	// iovecs limit length to 2GB(2^31)
+	if totalLen <= math.MaxInt32 {
+		return iovLen
+	}
+	// reset here
+	totalLen = math.MaxInt32
+	for i := 0; i < iovLen; i++ {
+		l := int(ivs[i].Len)
+		if l < totalLen {
+			totalLen -= l
+			continue
+		}
+		ivs[i].SetLen(totalLen)
+		iovLen = i + 1
+		resetIovecs(nil, ivs[iovLen:])
+		return iovLen
 	}
 	return iovLen
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

fix
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: Some syscalls use int32 to store size, overrunning will result in EINVAL
zh: 系统 io 调用使用 int32 存储 size, 超限调用会导致 EINVAL

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #179 