### PR TITLE
fix: poller read all data before connection close

### DIFF
--- a/connection_impl.go
+++ b/connection_impl.go
@@ -370,8 +370,6 @@ func (c *connection) initFDOperator() {
 func (c *connection) initFinalizer() {
 	c.AddCloseCallback(func(connection Connection) (err error) {
 		c.stop(flushing)
-		// stop the finalizing state to prevent conn.fill function to be performed
-		c.stop(finalizing)
 		c.operator.Free()
 		if err = c.netFD.Close(); err != nil {
 			logger.Printf("NETPOLL: netFD close failed: %v", err)
@@ -407,15 +405,10 @@ func (c *connection) waitRead(n int) (err error) {
 	}
 	// wait full n
 	for c.inputBuffer.Len() < n {
-		if c.IsActive() {
-			<-c.readTrigger
-			continue
+		if !c.IsActive() {
+			return Exception(ErrConnClosed, "wait read")
 		}
-		// confirm that fd is still valid.
-		if atomic.LoadUint32(&c.netFD.closed) == 0 {
-			return c.fill(n)
-		}
-		return Exception(ErrConnClosed, "wait read")
+		<-c.readTrigger
 	}
 	return nil
 }
@@ -432,12 +425,7 @@ func (c *connection) waitReadWithTimeout(n int) (err error) {
 	for c.inputBuffer.Len() < n {
 		if !c.IsActive() {
 			// cannot return directly, stop timer before !
-			// confirm that fd is still valid.
-			if atomic.LoadUint32(&c.netFD.closed) == 0 {
-				err = c.fill(n)
-			} else {
-				err = Exception(ErrConnClosed, "wait read")
-			}
+			err = Exception(ErrConnClosed, "wait read")
 			break
 		}
 
@@ -456,34 +444,6 @@ func (c *connection) waitReadWithTimeout(n int) (err error) {
 	// clean timer.C
 	if !c.readTimer.Stop() {
 		<-c.readTimer.C
-	}
-	return err
-}
-
-// fill data after connection is closed.
-func (c *connection) fill(need int) (err error) {
-	if !c.lock(finalizing) {
-		return ErrConnClosed
-	}
-	defer c.unlock(finalizing)
-
-	var n int
-	var bs [][]byte
-	for {
-		bs = c.inputs(c.inputBarrier.bs)
-	TryRead:
-		n, err = ioread(c.fd, bs, c.inputBarrier.ivs)
-		if err != nil {
-			break
-		}
-		if n == 0 {
-			// we must reuse bs that has been booked, otherwise will mess the input buffer
-			goto TryRead
-		}
-		c.inputAck(n)
-	}
-	if c.inputBuffer.Len() >= need {
-		return nil
 	}
 	return err
 }

--- a/connection_lock.go
+++ b/connection_lock.go
@@ -47,7 +47,6 @@ const (
 	closing key = iota
 	processing
 	flushing
-	finalizing
 	// total must be at the bottom.
 	total
 )

--- a/connection_test.go
+++ b/connection_test.go
@@ -395,7 +395,7 @@ func TestConnectionUntil(t *testing.T) {
 
 	buf, err := rconn.Reader().Until('\n')
 	Equal(t, len(buf), 100)
-	MustTrue(t, errors.Is(err, ErrEOF))
+	Assert(t, errors.Is(err, ErrConnClosed), err)
 }
 
 func TestBookSizeLargerThanMaxSize(t *testing.T) {

--- a/poll_default.go
+++ b/poll_default.go
@@ -50,3 +50,26 @@ func (p *defaultPoll) onhups() {
 		}
 	}(hups)
 }
+
+// readall read all left data before close connection
+func readall(op *FDOperator, br barrier) (err error) {
+	var bs = br.bs
+	var ivs = br.ivs
+	var n int
+	for {
+		bs = op.Inputs(br.bs)
+		if len(bs) == 0 {
+			return nil
+		}
+
+	TryRead:
+		n, err = ioread(op.FD, bs, ivs)
+		op.InputAck(n)
+		if err != nil {
+			return err
+		}
+		if n == 0 && err == nil {
+			goto TryRead
+		}
+	}
+}

--- a/poll_default.go
+++ b/poll_default.go
@@ -68,7 +68,7 @@ func readall(op *FDOperator, br barrier) (err error) {
 		if err != nil {
 			return err
 		}
-		if n == 0 && err == nil {
+		if n == 0 {
 			goto TryRead
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

chore

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: fix: poller read all data before connection close
zh: fix: poller 在连接关闭之前，尝试读取完所有数据

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
