### PR TITLE
fix: close the poll that has already been created when calling the openPoll fails

### DIFF
--- a/poll_default_bsd.go
+++ b/poll_default_bsd.go
@@ -24,15 +24,15 @@ import (
 	"unsafe"
 )
 
-func openPoll() Poll {
+func openPoll() (Poll, error) {
 	return openDefaultPoll()
 }
 
-func openDefaultPoll() *defaultPoll {
+func openDefaultPoll() (*defaultPoll, error) {
 	l := new(defaultPoll)
 	p, err := syscall.Kqueue()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	l.fd = p
 	_, err = syscall.Kevent(l.fd, []syscall.Kevent_t{{
@@ -41,10 +41,11 @@ func openDefaultPoll() *defaultPoll {
 		Flags:  syscall.EV_ADD | syscall.EV_CLEAR,
 	}}, nil, nil)
 	if err != nil {
-		panic(err)
+		syscall.Close(l.fd)
+		return nil, err
 	}
 	l.opcache = newOperatorCache()
-	return l
+	return l, nil
 }
 
 type defaultPoll struct {

--- a/poll_default_linux.go
+++ b/poll_default_linux.go
@@ -37,7 +37,7 @@ func openDefaultPoll() *defaultPoll {
 	var r0, _, e0 = syscall.Syscall(syscall.SYS_EVENTFD2, 0, 0, 0)
 	if e0 != 0 {
 		syscall.Close(p)
-		panic(err)
+		panic(e0)
 	}
 
 	poll.Reset = poll.reset

--- a/poll_test.go
+++ b/poll_test.go
@@ -31,7 +31,9 @@ func TestPollTrigger(t *testing.T) {
 	t.Skip()
 	var trigger int
 	var stop = make(chan error)
-	var p = openDefaultPoll()
+	var p, err = openDefaultPoll()
+	MustNil(t, err)
+
 	go func() {
 		stop <- p.Wait()
 	}()
@@ -46,7 +48,7 @@ func TestPollTrigger(t *testing.T) {
 	Equal(t, trigger, 2)
 
 	p.Close()
-	err := <-stop
+	err = <-stop
 	MustNil(t, err)
 }
 
@@ -65,7 +67,8 @@ func TestPollMod(t *testing.T) {
 		return nil
 	}
 	var stop = make(chan error)
-	var p = openDefaultPoll()
+	var p, err = openDefaultPoll()
+	MustNil(t, err)
 	go func() {
 		stop <- p.Wait()
 	}()
@@ -73,7 +76,6 @@ func TestPollMod(t *testing.T) {
 	var rfd, wfd = GetSysFdPairs()
 	var rop = &FDOperator{FD: rfd, OnRead: read, OnWrite: write, OnHup: hup, poll: p}
 	var wop = &FDOperator{FD: wfd, OnRead: read, OnWrite: write, OnHup: hup, poll: p}
-	var err error
 	var r, w, h int32
 	r, w, h = atomic.LoadInt32(&rn), atomic.LoadInt32(&wn), atomic.LoadInt32(&hn)
 	Assert(t, r == 0 && w == 0 && h == 0, r, w, h)
@@ -113,7 +115,8 @@ func TestPollMod(t *testing.T) {
 }
 
 func TestPollClose(t *testing.T) {
-	var p = openDefaultPoll()
+	var p, err = openDefaultPoll()
+	MustNil(t, err)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -126,7 +129,7 @@ func TestPollClose(t *testing.T) {
 
 func BenchmarkPollMod(b *testing.B) {
 	b.StopTimer()
-	var p = openDefaultPoll()
+	var p, _ = openDefaultPoll()
 	r, _ := GetSysFdPairs()
 	var operator = &FDOperator{FD: r}
 	p.Control(operator, PollReadable)


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:close the poll that has already been created when calling the openPoll fails
zh: 当调用openPoll失败的时候，需要释放之前创建成功的poll资源，而不是直接panic


#### (Optional) Which issue(s) this PR fixes:
