### PR TITLE
optimize: ignore EOF when read a closed connection

### DIFF
--- a/poll_default_bsd.go
+++ b/poll_default_bsd.go
@@ -112,7 +112,7 @@ func (p *defaultPoll) Wait() error {
 				}
 			}
 			if triggerHup && triggerRead && operator.Inputs != nil { // read all left data if peer send and close
-				if err = readall(operator, barriers[i]); err != nil {
+				if err = readall(operator, barriers[i]); err != nil && !errors.Is(err, ErrEOF) {
 					logger.Printf("NETPOLL: readall(fd=%d) before close: %s", operator.FD, err.Error())
 				}
 			}

--- a/poll_default_linux.go
+++ b/poll_default_linux.go
@@ -15,6 +15,7 @@
 package netpoll
 
 import (
+	"errors"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -164,7 +165,7 @@ func (p *defaultPoll) handler(events []epollevent) (closed bool) {
 			}
 		}
 		if triggerHup && triggerRead && operator.Inputs != nil { // read all left data if peer send and close
-			if err := readall(operator, p.barriers[i]); err != nil {
+			if err := readall(operator, p.barriers[i]); err != nil && !errors.Is(err, ErrEOF) {
 				logger.Printf("NETPOLL: readall(fd=%d) before close: %s", operator.FD, err.Error())
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

optimize: 当读取一个已经关闭连接时，忽略 EOF 错误

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: When a connection closed but still have some data could be read, it will read all left data until EOF. So need to ignore EOF error.
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
