### PR TITLE
fix: 修复sys_exec_test.go函数中TestReadv测试函数使用错误

### DIFF
--- a/sys_exec.go
+++ b/sys_exec.go
@@ -86,6 +86,7 @@ func readv(fd int, bs [][]byte, ivs []syscall.Iovec) (n int, err error) {
 	}
 	// syscall
 	r, _, e := syscall.RawSyscall(syscall.SYS_READV, uintptr(fd), uintptr(unsafe.Pointer(&ivs[0])), uintptr(iovLen))
+	resetIovecs(bs, ivs[:iovLen])
 	if e != 0 {
 		return int(r), syscall.Errno(e)
 	}

--- a/sys_exec.go
+++ b/sys_exec.go
@@ -86,7 +86,6 @@ func readv(fd int, bs [][]byte, ivs []syscall.Iovec) (n int, err error) {
 	}
 	// syscall
 	r, _, e := syscall.RawSyscall(syscall.SYS_READV, uintptr(fd), uintptr(unsafe.Pointer(&ivs[0])), uintptr(iovLen))
-	resetIovecs(bs, ivs[:iovLen])
 	if e != 0 {
 		return int(r), syscall.Errno(e)
 	}
@@ -94,8 +93,10 @@ func readv(fd int, bs [][]byte, ivs []syscall.Iovec) (n int, err error) {
 }
 
 // TODO: read from sysconf(_SC_IOV_MAX)? The Linux default is
-//  1024 and this seems conservative enough for now. Darwin's
-//  UIO_MAXIOV also seems to be 1024.
+//
+//	1024 and this seems conservative enough for now. Darwin's
+//	UIO_MAXIOV also seems to be 1024.
+//
 // iovecs limit length to 2GB(2^31)
 func iovecs(bs [][]byte, ivs []syscall.Iovec) (iovLen int) {
 	totalLen := 0

--- a/sys_exec_test.go
+++ b/sys_exec_test.go
@@ -105,18 +105,23 @@ func TestReadv(t *testing.T) {
 	w3, _ := syscall.Write(w, vs[2])
 	Equal(t, w1+w2+w3, 31)
 
-	var barrier = barrier{}
-	barrier.bs = [][]byte{
+	var barrier = barrier{
+		bs: make([][]byte, 4),
+	}
+	res := [][]byte{
 		make([]byte, 0),
 		make([]byte, 10),
 		make([]byte, 11),
 		make([]byte, 10),
 	}
+	for i := range res {
+		barrier.bs[i] = res[i]
+	}
 	barrier.ivs = make([]syscall.Iovec, len(barrier.bs))
 	rn, err := readv(r, barrier.bs, barrier.ivs)
 	MustNil(t, err)
 	Equal(t, rn, 31)
-	for i, v := range barrier.bs {
+	for i, v := range res {
 		t.Logf("READ [%d] %s", i, v)
 	}
 }


### PR DESCRIPTION
# 问题描述

项目路径下提供了一个测试用例文件: sys_exec_test.go  , 其中提供了一个测试函数TestReadv，用于测试Readv系统调用：

```go
func TestReadv(t *testing.T) {
	// 1. 向fd中写入数据
	r, w := GetSysFdPairs()
	vs := [][]byte{
		[]byte("first line"),  // len=10
		[]byte("second line"), // len=11
		[]byte("third line"),  // len=10
	}
	w1, _ := syscall.Write(w, vs[0])
	w2, _ := syscall.Write(w, vs[1])
	w3, _ := syscall.Write(w, vs[2])
	Equal(t, w1+w2+w3, 31)

	// 2. 准备bs和ivs缓冲区
	var barrier = barrier{}
	barrier.bs = [][]byte{
		make([]byte, 0),
		make([]byte, 10),
		make([]byte, 11),
		make([]byte, 10),
	}
	barrier.ivs = make([]syscall.Iovec, len(barrier.bs))
	// 3. 调用readv系统调用,读取数据到ivs , ivs缓冲区指针指向了bs
	rn, err := readv(r, barrier.bs, barrier.ivs)
	MustNil(t, err)
	Equal(t, rn, 31)
	// 4. 打印bs缓冲区中的数据
	for i, v := range barrier.bs {
		t.Logf("READ [%d] %s", i, v)
	}
}
```
在没有修改前，readv的源码如下:
```go
// readv wraps the readv system call.
// return 0, nil means EOF.
func readv(fd int, bs [][]byte, ivs []syscall.Iovec) (n int, err error) {
        // 依次为每个ivs[i].base 与 bs[i] 建立映射关系
	iovLen := iovecs(bs, ivs)
	if iovLen == 0 {
		return 0, nil
	}
	// syscall
	r, _, e := syscall.RawSyscall(syscall.SYS_READV, uintptr(fd), uintptr(unsafe.Pointer(&ivs[0])), uintptr(iovLen))
        // 此处会清空bs和ivs缓冲区
	resetIovecs(bs, ivs[:iovLen])
	if e != 0 {
		return int(r), syscall.Errno(e)
	}
	return int(r), nil
}
```
最终输出的结果为 , 缓冲区中的数据为空，都被清空了，不符合预期:
```go
=== RUN   TestReadv
    sys_exec_test.go:120: READ [0] 
    sys_exec_test.go:120: READ [1] 
    sys_exec_test.go:120: READ [2] 
    sys_exec_test.go:120: READ [3] 
--- PASS: TestReadv (0.00s)
PASS
```
# 解决办法

将readv中清空缓冲区的方法调用移除:
```go
// readv wraps the readv system call.
// return 0, nil means EOF.
func readv(fd int, bs [][]byte, ivs []syscall.Iovec) (n int, err error) {
	iovLen := iovecs(bs, ivs)
	if iovLen == 0 {
		return 0, nil
	}
	// syscall
	r, _, e := syscall.RawSyscall(syscall.SYS_READV, uintptr(fd), uintptr(unsafe.Pointer(&ivs[0])), uintptr(iovLen))
	if e != 0 {
		return int(r), syscall.Errno(e)
	}
	return int(r), nil
}
```

再次运行测试用例，输出如下:

```go
=== RUN   TestReadv
    sys_exec_test.go:124: READ [0] 
    sys_exec_test.go:124: READ [1] first line
    sys_exec_test.go:124: READ [2] second line
    sys_exec_test.go:124: READ [3] third line
--- PASS: TestReadv (0.00s)
PASS
```