### PR TITLE
fix: connection leak when poller close connection but onRequest callback just finished

### DIFF
--- a/connection_onevent.go
+++ b/connection_onevent.go
@@ -210,7 +210,7 @@ func (c *connection) onProcess(isProcessable func(c *connection) bool, process f
 			}
 			process(c)
 		}
-		// Handling callback if connection has been closed.
+		// handling callback if connection has been closed.
 		if closedBy != none {
 			//  if closed by user when processing, it "may" needs detach
 			needDetach := closedBy == user
@@ -223,7 +223,17 @@ func (c *connection) onProcess(isProcessable func(c *connection) bool, process f
 			return
 		}
 		c.unlock(processing)
-		// Double check when exiting.
+		// Note: Poller's closeCallback call will try to get processing lock failed but here already neer to unlock processing.
+		//       So here we need to check connection state again, to avoid connection leak
+		// double check close state
+		if c.status(closing) != 0 && c.lock(processing) {
+			// poller will get the processing lock failed, here help poller do closeCallback
+			// fd must already detach by poller
+			c.closeCallback(false, false)
+			panicked = false
+			return
+		}
+		// double check isProcessable
 		if isProcessable(c) && c.lock(processing) {
 			goto START
 		}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

fix: 当对端关闭连接但是 OnRequest 回调刚刚返回时，连接可能泄漏的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
Triggered Case:
1. client write and wait read
2. netpoll server OnRequest: read and write , OnRequest returned but still hold processing lock
3. client read finish and close connection
4. netpoll server receive EPOLLHUP and detach FD and call closeCallback but try to get processing lock failed
5. netpoll server OnRequest: release processing lock and return OnRequest
6. nothing will check connection state again so connection may leak.

Occur mainly in UDS server with short connection client . For TCP case, close a connection may not so quick to pass to server thread so server have a chance to finish OnRequest callback first.

zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
