### PR TITLE
fix: ctx race when disconnect callback run with connect callback

### DIFF
--- a/connection_impl.go
+++ b/connection_impl.go
@@ -45,8 +45,9 @@ type connection struct {
 	outputBuffer    *LinkBuffer
 	outputBarrier   *barrier
 	supportZeroCopy bool
-	maxSize         int // The maximum size of data between two Release().
-	bookSize        int // The size of data that can be read at once.
+	maxSize         int   // The maximum size of data between two Release().
+	bookSize        int   // The size of data that can be read at once.
+	connected       int32 // The OnConnect callback finished state
 }
 
 var (
@@ -323,6 +324,7 @@ func (c *connection) init(conn Conn, opts *options) (err error) {
 	c.bookSize, c.maxSize = pagesize, pagesize
 	c.inputBuffer, c.outputBuffer = NewLinkBuffer(pagesize), NewLinkBuffer()
 	c.outputBarrier = barrierPool.Get().(*barrier)
+	c.connected = 0
 
 	c.initNetFD(conn) // conn must be *netFD{}
 	c.initFDOperator()

--- a/connection_impl.go
+++ b/connection_impl.go
@@ -47,7 +47,7 @@ type connection struct {
 	supportZeroCopy bool
 	maxSize         int   // The maximum size of data between two Release().
 	bookSize        int   // The size of data that can be read at once.
-	connected       int32 // The OnConnect callback finished state
+	state           int32 // 0: not connected, 1: connected, 2: disconnected. Connection state should be changed sequentially.
 }
 
 var (
@@ -324,7 +324,7 @@ func (c *connection) init(conn Conn, opts *options) (err error) {
 	c.bookSize, c.maxSize = pagesize, pagesize
 	c.inputBuffer, c.outputBuffer = NewLinkBuffer(pagesize), NewLinkBuffer()
 	c.outputBarrier = barrierPool.Get().(*barrier)
-	c.connected = 0
+	c.state = 0
 
 	c.initNetFD(conn) // conn must be *netFD{}
 	c.initFDOperator()

--- a/connection_lock.go
+++ b/connection_lock.go
@@ -45,6 +45,7 @@ type key int32
 
 const (
 	closing key = iota
+	connecting
 	processing
 	flushing
 	// total must be at the bottom.

--- a/eventloop.go
+++ b/eventloop.go
@@ -41,6 +41,11 @@ type EventLoop interface {
 |   Read first byte                    |    OnRequest      | Conn is ready for read or write
 |   Peer closed but conn is active     |    OnDisconnect   | Conn access will race with OnRequest function
 |   Self closed and conn is closed     |    CloseCallback  | Conn is destroyed
+
+Execution Order:
+  OnPrepare => OnConnect => OnRequest      => CloseCallback
+                            OnDisconnect
+Note: only OnRequest and OnDisconnect will be executed in parallel
 */
 
 // OnPrepare is used to inject custom preparation at connection initialization,

--- a/netpoll_test.go
+++ b/netpoll_test.go
@@ -137,14 +137,14 @@ func TestOnConnectWrite(t *testing.T) {
 }
 
 func TestOnDisconnect(t *testing.T) {
-	var ctxKey = struct{}{}
+	type ctxKey struct{}
 	var network, address = "tcp", ":8888"
 	var canceled, closed int32
 	var conns int32 = 100
 	req := "ping"
 	var loop = newTestEventLoop(network, address,
 		func(ctx context.Context, connection Connection) error {
-			cancelFunc, _ := ctx.Value(ctxKey).(context.CancelFunc)
+			cancelFunc, _ := ctx.Value(ctxKey{}).(context.CancelFunc)
 			MustTrue(t, cancelFunc != nil)
 			Assert(t, ctx.Done() != nil)
 
@@ -164,10 +164,10 @@ func TestOnDisconnect(t *testing.T) {
 				return nil
 			})
 			ctx, cancel := context.WithCancel(ctx)
-			return context.WithValue(ctx, ctxKey, cancel)
+			return context.WithValue(ctx, ctxKey{}, cancel)
 		}),
 		WithOnDisconnect(func(ctx context.Context, conn Connection) {
-			cancelFunc, _ := ctx.Value(ctxKey).(context.CancelFunc)
+			cancelFunc, _ := ctx.Value(ctxKey{}).(context.CancelFunc)
 			MustTrue(t, cancelFunc != nil)
 			cancelFunc()
 		}),
@@ -192,6 +192,56 @@ func TestOnDisconnect(t *testing.T) {
 	Equal(t, atomic.LoadInt32(&closed), conns)
 	Equal(t, atomic.LoadInt32(&canceled), conns)
 
+	err := loop.Shutdown(context.Background())
+	MustNil(t, err)
+}
+
+func TestOnDisconnectWhenOnConnect(t *testing.T) {
+	type ctxPrepareKey struct{}
+	type ctxConnectKey struct{}
+	var network, address = "tcp", ":8888"
+	var conns int32 = 100
+	var wg sync.WaitGroup
+	wg.Add(int(conns) * 3)
+	var loop = newTestEventLoop(network, address,
+		func(ctx context.Context, connection Connection) error {
+			_, _ = connection.Reader().Next(connection.Reader().Len())
+			return nil
+		},
+		WithOnPrepare(func(connection Connection) context.Context {
+			defer wg.Done()
+			var counter int32
+			return context.WithValue(context.Background(), ctxPrepareKey{}, &counter)
+		}),
+		WithOnConnect(func(ctx context.Context, conn Connection) context.Context {
+			defer wg.Done()
+			t.Logf("OnConnect: %v", conn.RemoteAddr())
+			time.Sleep(time.Millisecond * 10) // wait for closed called
+			counter := ctx.Value(ctxPrepareKey{}).(*int32)
+			ok := atomic.CompareAndSwapInt32(counter, 0, 1)
+			Assert(t, ok)
+			return context.WithValue(ctx, ctxConnectKey{}, "123")
+		}),
+		WithOnDisconnect(func(ctx context.Context, conn Connection) {
+			defer wg.Done()
+			t.Logf("OnDisconnect: %v", conn.RemoteAddr())
+			counter, _ := ctx.Value(ctxPrepareKey{}).(*int32)
+			ok := atomic.CompareAndSwapInt32(counter, 1, 2)
+			Assert(t, ok)
+			v := ctx.Value(ctxConnectKey{}).(string)
+			Equal(t, v, "123")
+		}),
+	)
+
+	for i := int32(0); i < conns; i++ {
+		var conn, err = DialConnection(network, address, time.Second)
+		MustNil(t, err)
+		err = conn.Close()
+		t.Logf("Close: %v", conn.LocalAddr())
+		MustNil(t, err)
+	}
+
+	wg.Wait()
 	err := loop.Shutdown(context.Background())
 	MustNil(t, err)
 }


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

fix: 修复当 disconnect 与 connect 回调同时运行时，访问 ctx race 的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
