### PR TITLE
feat: allow GetBytes to get all bytes

### DIFF
--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -557,8 +557,17 @@ func (b *LinkBuffer) Bytes() []byte {
 }
 
 // GetBytes will read and fill the slice p as much as possible.
+// If p is not passed, return all readable bytes.
 func (b *LinkBuffer) GetBytes(p [][]byte) (vs [][]byte) {
 	node, flush := b.read, b.flush
+	if len(p) == 0 {
+		n := 0
+		for ; node != flush; node = node.next {
+			n++
+		}
+		node = b.read
+		p = make([][]byte, n)
+	}
 	var i int
 	for i = 0; node != flush && i < len(p); node = node.next {
 		if node.Len() > 0 {

--- a/nocopy_linkbuffer_race.go
+++ b/nocopy_linkbuffer_race.go
@@ -599,10 +599,19 @@ func (b *LinkBuffer) Bytes() []byte {
 }
 
 // GetBytes will read and fill the slice p as much as possible.
+// If p is not passed, return all readable bytes.
 func (b *LinkBuffer) GetBytes(p [][]byte) (vs [][]byte) {
 	b.Lock()
 	defer b.Unlock()
 	node, flush := b.read, b.flush
+	if len(p) == 0 {
+		n := 0
+		for ; node != flush; node = node.next {
+			n++
+		}
+		node = b.read
+		p = make([][]byte, n)
+	}
 	var i int
 	for i = 0; node != flush && i < len(p); node = node.next {
 		if node.Len() > 0 {

--- a/nocopy_linkbuffer_test.go
+++ b/nocopy_linkbuffer_test.go
@@ -84,6 +84,31 @@ func TestLinkBuffer(t *testing.T) {
 	Equal(t, buf.Len(), 100)
 }
 
+func TestGetBytes(t *testing.T) {
+	buf := NewLinkBuffer()
+	var (
+		num         = 10
+		b           = 1
+		expectedLen = 0
+	)
+	for i := 0; i < num; i++ {
+		expectedLen += b
+		n, err := buf.WriteBinary(make([]byte, b))
+		MustNil(t, err)
+		Equal(t, n, b)
+		b *= 10
+	}
+	buf.Flush()
+	Equal(t, int(buf.length), expectedLen)
+	bs := buf.GetBytes(nil)
+	actualLen := 0
+	for i := 0; i < len(bs); i++ {
+		actualLen += len(bs[i])
+	}
+	Equal(t, actualLen, expectedLen)
+
+}
+
 // TestLinkBufferWithZero test more case with n is invalid.
 func TestLinkBufferWithInvalid(t *testing.T) {
 	// clean & new


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
