### PR TITLE
feat: look for the File() method instead of assuming TCP or Unix Listeners

### DIFF
--- a/net_listener.go
+++ b/net_listener.go
@@ -144,18 +144,16 @@ func (ln *listener) Fd() (fd int) {
 	return ln.fd
 }
 
+type filer interface {
+	File() (*os.File, error)
+}
+
 func (ln *listener) parseFD() (err error) {
-	switch netln := ln.ln.(type) {
-	case *net.TCPListener:
-		ln.file, err = netln.File()
-	case *net.UnixListener:
-		ln.file, err = netln.File()
-	default:
-		return errors.New("listener type can't support")
+	netln, ok := ln.ln.(filer)
+	if !ok {
+		return errors.New("listener type not supported (no File() method)")
 	}
-	if err != nil {
-		return err
-	}
+	ln.file, err = netln.File()
 	ln.fd = int(ln.file.Fd())
 	return nil
 }

--- a/net_listener.go
+++ b/net_listener.go
@@ -154,6 +154,12 @@ func (ln *listener) parseFD() (err error) {
 		return errors.New("listener type not supported (no File() method)")
 	}
 	ln.file, err = netln.File()
+	if err != nil {
+		return err
+	}
+	if ln.file == nil {
+		return errors.New("listener type not supported (no file handle)")
+	}
 	ln.fd = int(ln.file.Fd())
 	return nil
 }


### PR DESCRIPTION
Make the underlying listeners more generic, by looking for an interface instead of the type. This makes things more generic and extensible.

#### What type of PR is this?
feat: A new feature/optimization

#### Check the PR title.

- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: When trying to get the file descriptor from the Listener, just check for the File() method/Interface instead of assuming TCP or Unix Listeners. This is more generic and extensible.
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:


#### (optional) The PR that updates user documentation:
