### PR TITLE
fix: _typos.toml and  some typos

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,10 @@
+# Typo check: https://github.com/crate-ci/typos
+
+[files]
+extend-exclude = ["go.sum"]
+
+[default.extend-identifiers]
+# *sigh* this just isn't worth the cost of fixing
+nd = "nd"
+paniced = "paniced"
+write_datas = "write_datas"

--- a/connection_test.go
+++ b/connection_test.go
@@ -601,7 +601,7 @@ func TestConnectionServerClose(t *testing.T) {
 	go func() {
 		err := el.Serve(ln)
 		if err != nil {
-			t.Logf("servce end with error: %v", err)
+			t.Logf("service end with error: %v", err)
 		}
 	}()
 
@@ -658,7 +658,7 @@ func TestConnectionDailTimeoutAndClose(t *testing.T) {
 	go func() {
 		err := el.Serve(ln)
 		if err != nil {
-			t.Logf("servce end with error: %v", err)
+			t.Logf("service end with error: %v", err)
 		}
 	}()
 

--- a/net_dialer.go
+++ b/net_dialer.go
@@ -54,7 +54,7 @@ func (d *dialer) DialConnection(network, address string, timeout time.Duration) 
 	switch network {
 	case "tcp", "tcp4", "tcp6":
 		return d.dialTCP(ctx, network, address)
-	// case "udp", "udp4", "udp6":  // TODO: unsupport now
+	// case "udp", "udp4", "udp6":  // TODO: unsupported now
 	case "unix", "unixgram", "unixpacket":
 		raddr := &UnixAddr{
 			UnixAddr: net.UnixAddr{Name: address, Net: network},

--- a/netpoll_test.go
+++ b/netpoll_test.go
@@ -542,7 +542,7 @@ func TestServerAcceptWhenTooManyOpenFiles(t *testing.T) {
 		},
 		WithOnConnect(func(ctx context.Context, connection Connection) context.Context {
 			atomic.AddInt32(&connected, 1)
-			t.Logf("Conn[%s] accpeted", connection.RemoteAddr())
+			t.Logf("Conn[%s] accepted", connection.RemoteAddr())
 			return ctx
 		}),
 		WithOnDisconnect(func(ctx context.Context, connection Connection) {


### PR DESCRIPTION
1. add the _typos.toml file and configuration to pass the detection of typos(Typos has been used in some projects such as hertz and kitex).
2. fix some typos.


<img width="895" alt="image" src="https://github.com/cloudwego/netpoll/assets/58761705/922e5b28-ce03-4d47-abe6-dd8156cc454b">
