### PR TITLE
fix: Peek OOM and performance issue

### DIFF
--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -131,14 +131,14 @@ func (b *UnsafeLinkBuffer) Peek(n int) (p []byte, err error) {
 	}
 
 	// multiple nodes
-	// always use malloc, since we will reuse b.cachePeek
+
+	// try to make use of the cap of b.cachePeek, if can't, free it.
 	if b.cachePeek != nil && cap(b.cachePeek) < n {
 		free(b.cachePeek)
 		b.cachePeek = nil
 	}
 	if b.cachePeek == nil {
-		b.cachePeek = malloc(n, n)
-		b.cachePeek = b.cachePeek[:0] // init with zero len, will append later
+		b.cachePeek = malloc(0, n) // init with zero len, will append later
 	}
 	p = b.cachePeek
 	if len(p) >= n {

--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -142,8 +142,9 @@ func (b *UnsafeLinkBuffer) Peek(n int) (p []byte, err error) {
 	}
 	p = b.cachePeek
 	if len(p) >= n {
-		// in case we peek smaller than last time
-		// we will reset cachePeek when Next or Skip
+		// in case we peek smaller than last time,
+		// we can return cache data directly.
+		// we will reset cachePeek when Next or Skip, no worries about stale data
 		return p[:n], nil
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复 Peek 调用导致的性能与内存问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
Originally, when we have data in more than one `linkBufferNode`,  
Each `Peek` call will create a new buffer for returning data, and put it in cache list. 
when the data grows larger, it would cause OOM if we can't release the cache in time.
This PR will reuse a `cachePeek` for `Peek` for memory and performance friendly, especially peeking a large buffer.
The `Next` method can also use the implementation like this one when it becomes stable.

zh(optional): 
在原来的实现里面，我们如果数据存放在多于一个的 `linkBufferNode`，
那么每次的 `Peek` 调用都会新建一个buffer来返回数据，并且会放在cache列表里。
当数据增长，这会导致OOM问题，如果我们不能及时回收cache里的数据。
这个PR对于`Peek`调用会复用一个`cachePeek`，对内存和性能更为友好，特别是peek数据量大的场景。
当这个实现稳定后，`Next` 方法也可以使用这方式来优化内存占用。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
