### PR TITLE
perf: Memory alignment to improve operatorCache memory efficiency

### DIFF
--- a/fd_operator_cache.go
+++ b/fd_operator_cache.go
@@ -28,13 +28,13 @@ func newOperatorCache() *operatorCache {
 }
 
 type operatorCache struct {
-	locked int32
 	first  *FDOperator
 	cache  []*FDOperator
+	locked int32
 	// freelist store the freeable operator
 	// to reduce GC pressure, we only store op index here
-	freelist   []int32
 	freelocked int32
+	freelist   []int32
 }
 
 func (c *operatorCache) alloc() *FDOperator {


### PR DESCRIPTION
#### What type of PR is this?
perf

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the 


#### (Optional) Translate the PR title into Chinese.
内存对齐，提高operatorCache内存效率

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:Due to the characteristics of golang memory alignment, locked and freelocked need to be placed in adjacent positions, which can reduce the size of the operatorCache structure from 72 bytes to 64 bytes, keep it within one cache line, improve memory utilization, and reduce cache miss.
In addition, you can consider filling blank memory between locked and freelocked, so that locked and freelocked are in different cache lines, reducing the frequency of competition between locks.

zh(optional): 由于golang内存对齐的特性，locked 和 freelocked 需要放在相邻位置，可以使 operatorCache结构体 从72个字节，变成64个字节，保持在一个缓存行之内，提高内存使用率，降低cachemiss。
另外可以考虑下locked和freelocked 之间，填充空白内存，使locked和freelocked分别处于不同的缓存行，降低锁之间相互竞争的频率。



#### (Optional) Which issue(s) this PR fixes:
Fixes #365


