### PR TITLE
perf: higher performance unsafeStringToSlice

### DIFF
--- a/nocopy.go
+++ b/nocopy.go
@@ -276,13 +276,13 @@ func unsafeSliceToString(b []byte) string {
 }
 
 // zero-copy slice convert to string
-func unsafeStringToSlice(s string) (b []byte) {
-	p := unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data)
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Data = uintptr(p)
-	hdr.Cap = len(s)
-	hdr.Len = len(s)
-	return b
+func unsafeStringToSlice(s string) []byte {
+	return *(*[]byte)(unsafe.Pointer(
+		&struct {
+			string
+			int
+		}{s, len(s)},
+	))
 }
 
 // malloc limits the cap of the buffer from mcache.

--- a/nocopy.go
+++ b/nocopy.go
@@ -16,7 +16,6 @@ package netpoll
 
 import (
 	"io"
-	"reflect"
 	"unsafe"
 
 	"github.com/bytedance/gopkg/lang/dirtmake"


### PR DESCRIPTION
Higher performance UnsafeStringToSlice

#### What type of PR is this?
perf

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en: higher performance unsafeStringToSlice



#### (Optional) Which issue(s) this PR fixes:
Fixes #370 

