### PR TITLE
perf: reduce make error cost of LinkBuffer.Until function

### DIFF
--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -31,6 +31,8 @@ const BinaryInplaceThreshold = block4k
 // LinkBufferCap that can be modified marks the minimum value of each node of LinkBuffer.
 var LinkBufferCap = block4k
 
+var untilErr = errors.New("link buffer read slice cannot find delim")
+
 var (
 	_ Reader = &LinkBuffer{}
 	_ Writer = &LinkBuffer{}
@@ -309,7 +311,7 @@ func (b *UnsafeLinkBuffer) ReadByte() (p byte, err error) {
 func (b *UnsafeLinkBuffer) Until(delim byte) (line []byte, err error) {
 	n := b.indexByte(delim, 0)
 	if n < 0 {
-		return nil, fmt.Errorf("link buffer read slice cannot find: '%b'", delim)
+		return nil, untilErr
 	}
 	return b.Next(n + 1)
 }


### PR DESCRIPTION
#### What type of PR is this?
perf

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
