### PR TITLE
fix: connection.Read copies directly from buffer nodes

### DIFF
--- a/connection_impl.go
+++ b/connection_impl.go
@@ -305,22 +305,13 @@ func (c *connection) WriteByte(b byte) (err error) {
 
 // Read behavior is the same as net.Conn, it will return io.EOF if buffer is empty.
 func (c *connection) Read(p []byte) (n int, err error) {
-	l := len(p)
-	if l == 0 {
+	if len(p) == 0 {
 		return 0, nil
 	}
 	if err = c.waitRead(1); err != nil {
 		return 0, err
 	}
-	if has := c.inputBuffer.Len(); has < l {
-		l = has
-	}
-	src, err := c.inputBuffer.Next(l)
-	n = copy(p, src)
-	if err == nil {
-		err = c.inputBuffer.Release()
-	}
-	return n, err
+	return c.inputBuffer.readTo(p), nil
 }
 
 // Write will Flush soon.

--- a/connection_test.go
+++ b/connection_test.go
@@ -122,7 +122,7 @@ func TestConnectionLargeWrite(t *testing.T) {
 	rconn.Close()
 }
 
-func TestConnectionRead(t *testing.T) {
+func TestConnectionReader(t *testing.T) {
 	r, w := GetSysFdPairs()
 	rconn, wconn := &connection{}, &connection{}
 	err := rconn.init(&netFD{fd: r}, nil)
@@ -150,6 +150,56 @@ func TestConnectionRead(t *testing.T) {
 		Equal(t, n, len(msg))
 	}
 	wg.Wait()
+	rconn.Close()
+}
+
+func TestConnectionRead(t *testing.T) {
+	r, w := GetSysFdPairs()
+	rconn := &connection{}
+	rconn.init(&netFD{fd: r}, nil)
+
+	writeAndWait := func(data []byte) {
+		syscall.Write(w, data)
+		for rconn.inputBuffer.Len() < len(data) {
+			runtime.Gosched()
+		}
+	}
+
+	// multi-node read
+	size := pagesize*2 + 100
+	msg := make([]byte, size)
+	for i := range msg {
+		msg[i] = byte(i % 251)
+	}
+	writeAndWait(msg)
+	buf := make([]byte, size)
+	n, err := rconn.Read(buf)
+	MustNil(t, err)
+	Equal(t, n, size)
+	Equal(t, string(buf), string(msg))
+
+	// len(p) > available
+	writeAndWait([]byte("short"))
+	buf = make([]byte, 1024)
+	n, err = rconn.Read(buf)
+	MustNil(t, err)
+	Equal(t, n, 5)
+	Equal(t, string(buf[:n]), "short")
+
+	// mixed Next + Read: prior ref must stay valid
+	chunk1 := []byte("first chunk!")
+	chunk2 := []byte("second chunk")
+	writeAndWait(append(chunk1, chunk2...))
+	ref, err := rconn.Reader().Next(len(chunk1))
+	MustNil(t, err)
+	buf = make([]byte, len(chunk2))
+	n, err = rconn.Read(buf)
+	MustNil(t, err)
+	Equal(t, n, len(chunk2))
+	Equal(t, string(buf), string(chunk2))
+	Equal(t, string(ref), string(chunk1))
+
+	rconn.Reader().Release()
 	rconn.Close()
 }
 

--- a/nocopy.go
+++ b/nocopy.go
@@ -243,8 +243,8 @@ func NewIOReadWriter(rw ReadWriter) io.ReadWriter {
 		return rwer
 	}
 	return &ioReadWriter{
-		ioReader: newIOReader(rw),
-		ioWriter: newIOWriter(rw),
+		Reader: NewIOReader(rw),
+		Writer: NewIOWriter(rw),
 	}
 }
 

--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -202,6 +202,42 @@ func (b *UnsafeLinkBuffer) Skip(n int) (err error) {
 	return nil
 }
 
+// readTo copies up to len(p) bytes from the buffer into p and advances the read pointer.
+// It releases fully-consumed nodes inline when safe (head == node), so callers
+// don't need to call Release afterwards. When prior Next refs are outstanding
+// (head != read), nodes are left for the caller's eventual Release.
+func (b *UnsafeLinkBuffer) readTo(p []byte) (n int) {
+	n = len(p)
+	if n == 0 {
+		return 0
+	}
+	if has := b.Len(); has < n {
+		n = has
+	}
+	if n == 0 {
+		return 0
+	}
+	b.recalLen(-n)
+	var l, pIdx int
+	for ack := n; ack > 0; ack -= l {
+		l = b.read.Len()
+		if l >= ack {
+			pIdx += copy(p[pIdx:], b.read.Next(ack))
+			break
+		} else if l > 0 {
+			pIdx += copy(p[pIdx:], b.read.Next(l))
+		}
+		old := b.read
+		b.read = b.read.next
+		if b.head == old {
+			b.head = b.read
+			old.Release()
+		}
+	}
+	_ = pIdx
+	return n
+}
+
 // Release the node that has been read.
 // b.flush == nil indicates that this LinkBuffer is created by LinkBuffer.Slice
 func (b *UnsafeLinkBuffer) Release() (err error) {

--- a/nocopy_linkbuffer_race.go
+++ b/nocopy_linkbuffer_race.go
@@ -59,6 +59,12 @@ func (b *SafeLinkBuffer) Until(delim byte) (line []byte, err error) {
 	return b.UnsafeLinkBuffer.Until(delim)
 }
 
+func (b *SafeLinkBuffer) readTo(p []byte) (n int) {
+	b.Lock()
+	defer b.Unlock()
+	return b.UnsafeLinkBuffer.readTo(p)
+}
+
 // Release implements Reader.
 func (b *SafeLinkBuffer) Release() (err error) {
 	b.Lock()

--- a/nocopy_linkbuffer_test.go
+++ b/nocopy_linkbuffer_test.go
@@ -911,3 +911,58 @@ func BenchmarkLinkBufferNoCopyRead(b *testing.B) {
 		}
 	})
 }
+
+func TestReadTo(t *testing.T) {
+	LinkBufferCap = 8
+
+	newBuf := func(data []byte) *LinkBuffer {
+		buf := NewLinkBuffer()
+		buf.WriteBinary(data)
+		buf.Flush()
+		return buf
+	}
+
+	// multi-node read
+	msg := make([]byte, 24)
+	for i := range msg {
+		msg[i] = byte(i)
+	}
+	buf := newBuf(msg)
+	p := make([]byte, 24)
+	Equal(t, buf.readTo(p), 24)
+	Equal(t, string(p), string(msg))
+
+	// len(p) > available: caps at available
+	buf = newBuf([]byte("short"))
+	p = make([]byte, 1024)
+	Equal(t, buf.readTo(p), 5)
+	Equal(t, string(p[:5]), "short")
+
+	// inline release: head advances with read when no prior refs
+	buf = newBuf(msg)
+	buf.readTo(make([]byte, 20))
+	MustTrue(t, buf.head == buf.read)
+
+	// mixed Next + readTo: head must NOT advance past unreleased Next refs
+	chunk1 := make([]byte, 10)
+	chunk2 := make([]byte, 10)
+	for i := range chunk1 {
+		chunk1[i] = byte('a' + i)
+	}
+	for i := range chunk2 {
+		chunk2[i] = byte('A' + i)
+	}
+	buf = newBuf(append(chunk1, chunk2...))
+	ref, err := buf.Next(len(chunk1))
+	MustNil(t, err)
+	MustTrue(t, buf.head != buf.read)
+
+	p = make([]byte, len(chunk2))
+	Equal(t, buf.readTo(p), len(chunk2))
+	Equal(t, string(p), string(chunk2))
+	MustTrue(t, buf.head != buf.read) // nodes retained
+	Equal(t, string(ref), string(chunk1))
+
+	buf.Release()
+	MustTrue(t, buf.head == buf.read)
+}

--- a/nocopy_readwriter.go
+++ b/nocopy_readwriter.go
@@ -225,11 +225,17 @@ func newIOReader(r Reader) *ioReader {
 var _ io.Reader = &ioReader{}
 
 // ioReader implements io.Reader.
+// Deprecated: connection already implements Read directly with optimized buffer access.
+// This wrapper exists only for external Reader implementations.
 type ioReader struct {
 	r Reader
 }
 
 // Read implements io.Reader.
+//
+// BUG: Read calls Release which invalidates any slices previously returned by Next or Peek
+// on the same Reader. Do not mix Next/Peek and Read on the same Reader without first
+// calling Release.
 func (r *ioReader) Read(p []byte) (n int, err error) {
 	l := len(p)
 	if l == 0 {
@@ -283,6 +289,6 @@ func (w *ioWriter) Write(p []byte) (n int, err error) {
 
 // ioReadWriter implements io.ReadWriter.
 type ioReadWriter struct {
-	*ioReader
-	*ioWriter
+	io.Reader
+	io.Writer
 }


### PR DESCRIPTION
The old implementation called Next(n) then copy(p, src). For multi-node reads, Next allocates an intermediate buffer and copies data into it, then copy duplicates it again into p — a double copy plus an unnecessary allocation.

Additionally, Next+Release in Read could invalidate zero-copy slices that the caller still holds from prior Reader.Next calls, since Release frees all consumed nodes from head to read indiscriminately.

Replace Next+copy+Release with readTo, which:
- Copies directly from underlying LinkBuffer nodes into p (single copy)
- Releases fully-consumed nodes inline only when safe (head == node), meaning no outstanding zero-copy references exist
- Skips inline release when head != read, leaving nodes for the caller's eventual Release call

Also fix ioReadWriter to embed io.Reader/io.Writer interfaces and add BUG/deprecation comments for ioReader.Read.