### PR TITLE
feat: deprecate AlwaysNoCopyRead and remove nocopy read path

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -153,64 +153,6 @@ func TestConnectionRead(t *testing.T) {
 	rconn.Close()
 }
 
-func TestConnectionNoCopyReadString(t *testing.T) {
-	err := Configure(Config{Feature: Feature{AlwaysNoCopyRead: true}})
-	MustNil(t, err)
-	defer func() {
-		err = Configure(Config{Feature: Feature{AlwaysNoCopyRead: false}})
-		MustNil(t, err)
-	}()
-
-	r, w := GetSysFdPairs()
-	rconn, wconn := &connection{}, &connection{}
-	rconn.init(&netFD{fd: r}, nil)
-	wconn.init(&netFD{fd: w}, nil)
-
-	size, cycleTime := 256, 100
-	// record historical data, check data consistency
-	readBucket := make([]string, cycleTime)
-	trigger := make(chan struct{})
-
-	// read data
-	go func() {
-		for i := 0; i < cycleTime; i++ {
-			// nocopy read string
-			str, err := rconn.Reader().ReadString(size)
-			MustNil(t, err)
-			Equal(t, len(str), size)
-			// release buffer node
-			rconn.Release()
-			// record current read string
-			readBucket[i] = str
-			// write next msg
-			trigger <- struct{}{}
-		}
-	}()
-
-	// write data
-	msg := make([]byte, size)
-	for i := 0; i < cycleTime; i++ {
-		byt := 'a' + byte(i%26)
-		for c := 0; c < size; c++ {
-			msg[c] = byt
-		}
-		n, err := wconn.Write(msg)
-		MustNil(t, err)
-		Equal(t, n, len(msg))
-		<-trigger
-	}
-
-	for i := 0; i < cycleTime; i++ {
-		byt := 'a' + byte(i%26)
-		for _, c := range readBucket[i] {
-			Equal(t, byte(c), byt)
-		}
-	}
-
-	wconn.Close()
-	rconn.Close()
-}
-
 func TestConnectionReadAfterClosed(t *testing.T) {
 	r, w := GetSysFdPairs()
 	rconn := &connection{}

--- a/netpoll_config.go
+++ b/netpoll_config.go
@@ -21,8 +21,7 @@ import (
 
 // global config
 var (
-	defaultLinkBufferSize   = pagesize
-	featureAlwaysNoCopyRead = false
+	defaultLinkBufferSize = pagesize
 )
 
 // Config expose some tuning parameters to control the internal behaviors of netpoll.
@@ -38,8 +37,6 @@ type Config struct {
 
 // Feature expose some new features maybe promoted as a default behavior but not yet.
 type Feature struct {
-	// AlwaysNoCopyRead allows some copy Read functions like ReadBinary/ReadString
-	// will use NoCopy read and will not reuse the underlying buffer.
-	// It gains more performance benefits when need read much big string/bytes in codec.
+	// Deprecated: AlwaysNoCopyRead has no effect and will be removed in a future release.
 	AlwaysNoCopyRead bool
 }

--- a/netpoll_unix.go
+++ b/netpoll_unix.go
@@ -65,7 +65,6 @@ func Configure(config Config) (err error) {
 		}
 	}
 
-	featureAlwaysNoCopyRead = config.AlwaysNoCopyRead
 	return nil
 }
 

--- a/nocopy.go
+++ b/nocopy.go
@@ -258,16 +258,11 @@ const (
 	pagesize  = block8k
 	mallocMax = block8k * block1k // mallocMax is 8MB
 
-	minReuseBytes = 64 // only reuse bytes if n >= minReuseBytes
-
 	defaultLinkBufferMode = 0
-	// readonlyMask is used to set readonly mode,
-	// which indicate that the buffer node memory is not controlled by itself,
-	// so we cannot reuse the buffer or nocopy read it.
-	readonlyMask uint8 = 1 << 0 // 0000 0001
-	// nocopyReadMask is used to set nocopyRead mode,
-	// which indicate that the buffer node has been no copy read and cannot reuse the buffer.
-	nocopyReadMask uint8 = 1 << 1 // 0000 0010
+	// flagUnmanaged marks a buffer node whose memory is not allocated by the LinkBuffer
+	// (e.g. user-provided data via WriteDirect, or a zero-size node).
+	// Unmanaged nodes are not reusable and are skipped during buffer growth.
+	flagUnmanaged uint8 = 1 << 0 // 0000 0001
 )
 
 // zero-copy slice convert to string

--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -255,21 +255,6 @@ func (b *UnsafeLinkBuffer) readBinary(n int) (p []byte) {
 
 	// single node
 	if b.isSingleNode(n) {
-		// TODO: enable nocopy read mode when ensure no legacy depend on copy-read
-		// we cannot nocopy read a readonly mode buffer, since readonly buffer's memory is not controlled by itself
-		if !b.read.getMode(readonlyMask) {
-			// if readBinary use no-copy mode, it will cause more memory used but get higher memory access efficiently
-			// for example, if user's codec need to decode 10 strings and each have 100 bytes, here could help the codec
-			// no need to malloc 10 times and the string slice could have the compact memory allocation.
-			if b.read.getMode(nocopyReadMask) {
-				return b.read.Next(n)
-			}
-			if featureAlwaysNoCopyRead && n >= minReuseBytes {
-				b.read.setMode(nocopyReadMask, true)
-				return b.read.Next(n)
-			}
-		}
-		// if the underlying buffer too large, we shouldn't use no-copy mode
 		p = dirtmake.Bytes(n, n)
 		copy(p, b.read.Next(n))
 		return p
@@ -542,9 +527,9 @@ func (b *UnsafeLinkBuffer) WriteDirect(extra []byte, remainLen int) error {
 		newNode.off = malloc
 		newNode.buf = origin.buf[:malloc]
 		newNode.malloc = origin.malloc
-		newNode.setMode(readonlyMask, false)
+		newNode.unsetFlag(flagUnmanaged)
 		origin.malloc = malloc
-		origin.setMode(readonlyMask, true)
+		origin.setFlag(flagUnmanaged)
 
 		// link nodes
 		dataNode.next = newNode
@@ -739,7 +724,7 @@ func (b *UnsafeLinkBuffer) growth(n int) {
 		return
 	}
 	// the memory of readonly node if not malloc by us so should skip them
-	for b.write.getMode(readonlyMask) || cap(b.write.buf)-b.write.malloc < n {
+	for b.write.getFlag(flagUnmanaged) || cap(b.write.buf)-b.write.malloc < n {
 		if b.write.next == nil {
 			b.write.next = newLinkBufferNode(n)
 			b.write = b.write.next
@@ -785,7 +770,7 @@ func newLinkBufferNode(size int) *linkBufferNode {
 	// reset node offset
 	node.off, node.malloc, node.refer, node.mode = 0, 0, 1, defaultLinkBufferMode
 	if size <= 0 {
-		node.setMode(readonlyMask, true)
+		node.setFlag(flagUnmanaged)
 		return node
 	}
 	if size < LinkBufferCap {
@@ -879,19 +864,20 @@ func (node *linkBufferNode) Release() (err error) {
 	return nil
 }
 
-func (node *linkBufferNode) getMode(mask uint8) bool {
-	return (node.mode & mask) > 0
+func (node *linkBufferNode) getFlag(flag uint8) bool {
+	return node.mode&flag > 0
 }
 
-func (node *linkBufferNode) setMode(mask uint8, enable bool) {
-	if enable {
-		node.mode = node.mode | mask
-	} else {
-		node.mode = node.mode &^ mask
-	}
+func (node *linkBufferNode) setFlag(flag uint8) {
+	node.mode |= flag
 }
 
-// only non-readonly and copied-read node should be reusable
+func (node *linkBufferNode) unsetFlag(flag uint8) {
+	node.mode &^= flag
+}
+
+// reusable reports whether the node's buffer memory is owned by the LinkBuffer and can be recycled.
+// Called during Release to decide if node.buf should be returned to mcache via free.
 func (node *linkBufferNode) reusable() bool {
-	return node.mode&(readonlyMask|nocopyReadMask) == 0
+	return node.mode&flagUnmanaged == 0
 }

--- a/nocopy_linkbuffer_test.go
+++ b/nocopy_linkbuffer_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"reflect"
-	"runtime"
 	"sync/atomic"
 	"testing"
 )
@@ -523,113 +522,14 @@ func TestLinkBufferWriteDirect(t *testing.T) {
 	}
 }
 
-func TestLinkBufferNoCopyWriteAndRead(t *testing.T) {
-	err := Configure(Config{Feature: Feature{AlwaysNoCopyRead: true}})
-	MustNil(t, err)
-	defer func() {
-		err = Configure(Config{Feature: Feature{AlwaysNoCopyRead: false}})
-		MustNil(t, err)
-	}()
-	// [origin_node:4096B] + [data_node:512B] + [new_node:16B] + [normal_node:4096B]
-	const (
-		mallocLen = 4096 * 2
-		originLen = 4096
-		dataLen   = 512
-		newLen    = 16
-		normalLen = 4096
-	)
-	buf := NewLinkBuffer()
-	bt, _ := buf.Malloc(mallocLen)
-	originBuf := bt[:originLen]
-	newBuf := bt[originLen : originLen+newLen]
-
-	// write origin_node
-	for i := 0; i < originLen; i++ {
-		bt[i] = 'a'
-	}
-	// write data_node
-	userBuf := make([]byte, dataLen)
-	for i := 0; i < len(userBuf); i++ {
-		userBuf[i] = 'b'
-	}
-	buf.WriteDirect(userBuf, mallocLen-originLen) // nocopy write
-	// write new_node
-	for i := 0; i < newLen; i++ {
-		bt[originLen+i] = 'c'
-	}
-	buf.MallocAck(originLen + dataLen + newLen)
-	buf.Flush()
-	// write normal_node
-	normalBuf, _ := buf.Malloc(normalLen)
-	for i := 0; i < normalLen; i++ {
-		normalBuf[i] = 'd'
-	}
-	buf.Flush()
-	Equal(t, buf.Len(), originLen+dataLen+newLen+normalLen)
-
-	// copy read origin_node
-	bt, _ = buf.ReadBinary(originLen)
-	for i := 0; i < len(bt); i++ {
-		MustTrue(t, bt[i] == 'a')
-	}
-	MustTrue(t, &bt[0] != &originBuf[0])
-	// next read node is data node and must be readonly and non-reusable
-	MustTrue(t, buf.read.next.getMode(readonlyMask) && !buf.read.next.reusable())
-	// copy read data_node
-	bt, _ = buf.ReadBinary(dataLen)
-	for i := 0; i < len(bt); i++ {
-		MustTrue(t, bt[i] == 'b')
-	}
-	MustTrue(t, &bt[0] != &userBuf[0])
-	// copy read new_node
-	bt, _ = buf.ReadBinary(newLen)
-	for i := 0; i < len(bt); i++ {
-		MustTrue(t, bt[i] == 'c')
-	}
-	MustTrue(t, &bt[0] != &newBuf[0])
-	// current read node is the new node and must not be reusable
-	newnode := buf.read
-	t.Log("newnode", newnode.getMode(readonlyMask), newnode.getMode(nocopyReadMask))
-	MustTrue(t, newnode.reusable())
-	var nodeReleased int32
-	runtime.SetFinalizer(&newnode.buf[0], func(_ *byte) {
-		atomic.AddInt32(&nodeReleased, 1)
-	})
-	// nocopy read normal_node
-	bt, _ = buf.ReadBinary(normalLen)
-	for i := 0; i < len(bt); i++ {
-		MustTrue(t, bt[i] == 'd')
-	}
-	MustTrue(t, &bt[0] == &normalBuf[0])
-	// normal buffer never should be released
-	runtime.SetFinalizer(&bt[0], func(_ *byte) {
-		atomic.AddInt32(&nodeReleased, 1)
-	})
-	_ = buf.Release()
-	MustTrue(t, newnode.buf == nil)
-	for atomic.LoadInt32(&nodeReleased) == 0 {
-		runtime.GC()
-		t.Log("newnode release checking")
-	}
-	Equal(t, atomic.LoadInt32(&nodeReleased), int32(1))
-	runtime.KeepAlive(normalBuf)
-}
-
 func TestLinkBufferBufferMode(t *testing.T) {
 	bufnode := newLinkBufferNode(0)
-	MustTrue(t, !bufnode.getMode(nocopyReadMask))
-	MustTrue(t, bufnode.getMode(readonlyMask))
+	MustTrue(t, bufnode.getFlag(flagUnmanaged))
 	MustTrue(t, !bufnode.reusable())
 
 	bufnode = newLinkBufferNode(1)
-	MustTrue(t, !bufnode.getMode(nocopyReadMask))
-	MustTrue(t, !bufnode.getMode(readonlyMask))
-	bufnode.setMode(nocopyReadMask, false)
-	MustTrue(t, !bufnode.getMode(nocopyReadMask))
+	MustTrue(t, !bufnode.getFlag(flagUnmanaged))
 	MustTrue(t, bufnode.reusable())
-	bufnode.setMode(nocopyReadMask, true)
-	MustTrue(t, bufnode.getMode(nocopyReadMask))
-	MustTrue(t, !bufnode.reusable())
 }
 
 func BenchmarkLinkBufferConcurrentReadWrite(b *testing.B) {


### PR DESCRIPTION
AlwaysNoCopyRead no longer has any effect. The feature field is kept for backward compatibility but marked deprecated. Removed the nocopyReadMask constant, the nocopy read code path in readBinary, and all related tests.

Also renamed getMode/setMode to getFlag/setFlag/unsetFlag and readonlyMask to flagUnmanaged for clarity.