### PR TITLE
fix: optimize connection.Read to copy directly from linked buffer

### DIFF
--- a/connection_impl.go
+++ b/connection_impl.go
@@ -305,22 +305,13 @@ func (c *connection) WriteByte(b byte) (err error) {
 
 // Read behavior is the same as net.Conn, it will return io.EOF if buffer is empty.
 func (c *connection) Read(p []byte) (n int, err error) {
-	l := len(p)
-	if l == 0 {
+	if len(p) == 0 {
 		return 0, nil
 	}
 	if err = c.waitRead(1); err != nil {
 		return 0, err
 	}
-	if has := c.inputBuffer.Len(); has < l {
-		l = has
-	}
-	src, err := c.inputBuffer.Next(l)
-	n = copy(p, src)
-	if err == nil {
-		err = c.inputBuffer.Release()
-	}
-	return n, err
+	return c.inputBuffer.readCopy(p), nil
 }
 
 // Write will Flush soon.

--- a/connection_test.go
+++ b/connection_test.go
@@ -153,6 +153,47 @@ func TestConnectionRead(t *testing.T) {
 	rconn.Close()
 }
 
+// TestConnectionIOReader tests the io.Reader Read method which uses readCopy internally.
+// Verifies that Read after Peek preserves exposed buffer until Release.
+func TestConnectionIOReader(t *testing.T) {
+	r, w := GetSysFdPairs()
+	rconn := &connection{}
+	rconn.init(&netFD{fd: r}, nil)
+
+	msg := make([]byte, 64)
+	for i := range msg {
+		msg[i] = byte(i)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Peek exposes the underlying buffer
+		pk, err := rconn.Peek(16)
+		MustNil(t, err)
+		Equal(t, len(pk), 16)
+
+		// Read copies without exposing
+		buf := make([]byte, 64)
+		n, err := rconn.Read(buf)
+		MustNil(t, err)
+		Equal(t, n, 64)
+		for i := 0; i < 64; i++ {
+			Equal(t, buf[i], byte(i))
+		}
+
+		// Peek data still valid before Release
+		for i := 0; i < 16; i++ {
+			Equal(t, pk[i], byte(i))
+		}
+		rconn.Release()
+	}()
+	syscall.Write(w, msg)
+	wg.Wait()
+	rconn.Close()
+	syscall.Close(w)
+}
+
 func TestConnectionReadAfterClosed(t *testing.T) {
 	r, w := GetSysFdPairs()
 	rconn := &connection{}

--- a/nocopy.go
+++ b/nocopy.go
@@ -243,8 +243,8 @@ func NewIOReadWriter(rw ReadWriter) io.ReadWriter {
 		return rwer
 	}
 	return &ioReadWriter{
-		ioReader: newIOReader(rw),
-		ioWriter: newIOWriter(rw),
+		Reader: NewIOReader(rw),
+		Writer: NewIOWriter(rw),
 	}
 }
 
@@ -263,6 +263,10 @@ const (
 	// (e.g. user-provided data via WriteDirect, or a zero-size node).
 	// Unmanaged nodes are not reusable and are skipped during buffer growth.
 	flagUnmanaged uint8 = 1 << 0 // 0000 0001
+	// flagReadExposed marks a buffer node whose underlying memory has been returned
+	// directly to user code via a zero-copy Reader method (Next, Peek, Slice, GetBytes).
+	// The buffer may still be referenced by user code until Release is called.
+	flagReadExposed uint8 = 1 << 1 // 0000 0010
 )
 
 // zero-copy slice convert to string

--- a/nocopy_linkbuffer.go
+++ b/nocopy_linkbuffer.go
@@ -79,6 +79,70 @@ func (b *UnsafeLinkBuffer) IsEmpty() (ok bool) {
 	return b.Len() == 0
 }
 
+// ------------------------------------------ implement copy reader ------------------------------------------
+
+// readCopy copies up to len(p) bytes from the buffer into p without exposing
+// the underlying buffer to user code (flagReadExposed is not set).
+// After copying, it releases consumed nodes where readExposed is false.
+// Nodes with readExposed are left for the next Release call.
+func (b *UnsafeLinkBuffer) readCopy(p []byte) (n int) {
+	l := len(p)
+	if l == 0 || b.Len() == 0 {
+		return 0
+	}
+	if has := b.Len(); has < l {
+		l = has
+	}
+	b.recalLen(-l)
+
+	// copy from nodes
+	for ack := l; ack > 0; {
+		if b.read.Len() == 0 {
+			b.read = b.read.next
+			continue
+		}
+		rd := b.read.Len()
+		if rd >= ack {
+			n += copy(p[n:], b.read.buf[b.read.off:b.read.off+ack])
+			b.read.off += ack
+			break
+		}
+		n += copy(p[n:], b.read.buf[b.read.off:])
+		ack -= rd
+		b.read = b.read.next
+	}
+
+	// advance read past empty nodes
+	for b.read != b.flush && b.read.Len() == 0 {
+		b.read = b.read.next
+	}
+	// release consumed nodes that are not readExposed.
+	// exposed nodes stay in the chain so Release() can free them later.
+	//
+	// Example: [exposed/consumed] → [not-exposed/consumed] → [read/partial]
+	// After:   head → [exposed] → [read/partial]
+	//          the middle node is detached and released.
+	var prev *linkBufferNode
+	newHead := b.read
+	for cur := b.head; cur != b.read; {
+		next := cur.next
+		if cur.readExposed() {
+			if prev == nil {
+				newHead = cur
+			}
+			prev = cur
+		} else {
+			cur.Release()
+			if prev != nil {
+				prev.next = next
+			}
+		}
+		cur = next
+	}
+	b.head = newHead
+	return n
+}
+
 // ------------------------------------------ implement zero-copy reader ------------------------------------------
 
 // Next implements Reader.
@@ -94,6 +158,7 @@ func (b *UnsafeLinkBuffer) Next(n int) (p []byte, err error) {
 
 	// single node
 	if b.isSingleNode(n) {
+		b.read.setFlag(flagReadExposed)
 		return b.read.Next(n), nil
 	}
 	// multiple nodes
@@ -131,6 +196,7 @@ func (b *UnsafeLinkBuffer) Peek(n int) (p []byte, err error) {
 	}
 	// single node
 	if b.isSingleNode(n) {
+		b.read.setFlag(flagReadExposed)
 		return b.read.Peek(n), nil
 	}
 
@@ -327,12 +393,14 @@ func (b *UnsafeLinkBuffer) Slice(n int) (r Reader, err error) {
 
 	// single node
 	if b.isSingleNode(n) {
+		b.read.setFlag(flagReadExposed)
 		node := b.read.Refer(n)
 		p.head, p.read, p.flush = node, node, node
 		return p, nil
 	}
 	// multiple nodes
 	l := b.read.Len()
+	b.read.setFlag(flagReadExposed)
 	node := b.read.Refer(l)
 	b.read = b.read.next
 
@@ -340,10 +408,12 @@ func (b *UnsafeLinkBuffer) Slice(n int) (r Reader, err error) {
 	for ack := n - l; ack > 0; ack = ack - l {
 		l = b.read.Len()
 		if l >= ack {
+			b.read.setFlag(flagReadExposed)
 			p.flush.next = b.read.Refer(ack)
 			p.flush = p.flush.next
 			break
 		} else if l > 0 {
+			b.read.setFlag(flagReadExposed)
 			p.flush.next = b.read.Refer(l)
 			p.flush = p.flush.next
 		}
@@ -608,11 +678,13 @@ func (b *UnsafeLinkBuffer) GetBytes(p [][]byte) (vs [][]byte) {
 	var i int
 	for i = 0; node != flush && i < len(p); node = node.next {
 		if node.Len() > 0 {
+			node.setFlag(flagReadExposed)
 			p[i] = node.buf[node.off:]
 			i++
 		}
 	}
 	if i < len(p) {
+		flush.setFlag(flagReadExposed)
 		p[i] = flush.buf[flush.off:]
 		i++
 	}
@@ -880,4 +952,10 @@ func (node *linkBufferNode) unsetFlag(flag uint8) {
 // Called during Release to decide if node.buf should be returned to mcache via free.
 func (node *linkBufferNode) reusable() bool {
 	return node.mode&flagUnmanaged == 0
+}
+
+// readExposed reports whether the node's buffer has been returned directly to user code
+// via a zero-copy Reader method and may still be referenced externally.
+func (node *linkBufferNode) readExposed() bool {
+	return node.mode&flagReadExposed > 0
 }

--- a/nocopy_linkbuffer_race.go
+++ b/nocopy_linkbuffer_race.go
@@ -29,6 +29,14 @@ type SafeLinkBuffer struct {
 	UnsafeLinkBuffer
 }
 
+// ------------------------------------------ implement copy reader ------------------------------------------
+
+func (b *SafeLinkBuffer) readCopy(p []byte) int {
+	b.Lock()
+	defer b.Unlock()
+	return b.UnsafeLinkBuffer.readCopy(p)
+}
+
 // ------------------------------------------ implement zero-copy reader ------------------------------------------
 
 // Next implements Reader.

--- a/nocopy_linkbuffer_test.go
+++ b/nocopy_linkbuffer_test.go
@@ -55,11 +55,13 @@ func TestLinkBuffer(t *testing.T) {
 	Equal(t, len(p), 28)
 	Equal(t, buf.Len(), 100)
 	MustNil(t, err)
+	MustTrue(t, buf.read.readExposed()) // single-node Next exposes buffer
 
 	p, err = buf.Peek(90)
 	Equal(t, len(p), 90)
 	Equal(t, buf.Len(), 100)
 	MustNil(t, err)
+	MustTrue(t, buf.read.readExposed()) // single-node Peek exposes buffer
 
 	read := buf.read
 	Equal(t, buf.head, head)
@@ -249,6 +251,8 @@ func TestLinkBufferMultiNode(t *testing.T) {
 	Equal(t, buf.read.next.Len(), 7)
 	Equal(t, buf.flush.off, 0)
 	Equal(t, buf.flush.malloc, 7)
+	MustTrue(t, buf.read.readExposed())   // single-node Next
+	MustTrue(t, !buf.flush.readExposed()) // not touched yet
 
 	// Peek
 	p, _ = buf.Peek(4)
@@ -278,6 +282,7 @@ func TestLinkBufferMultiNode(t *testing.T) {
 	Equal(t, buf.read.Len(), 2)
 	Equal(t, buf.flush.off, 0)
 	Equal(t, buf.flush.malloc, 7)
+	MustTrue(t, !buf.flush.readExposed()) // multi-node Peek copies, doesn't expose
 	// Peek ends
 
 	buf.book(block8k, block8k)
@@ -349,6 +354,7 @@ func TestLinkBufferRefer(t *testing.T) {
 	Equal(t, buf.flush.off, 0)
 	Equal(t, buf.flush.malloc, 7)
 	Equal(t, cap(buf.flush.buf), 8)
+	MustTrue(t, buf.read.readExposed()) // single-node Next
 
 	// readv
 	_rbuf, err := buf.Slice(4)
@@ -526,10 +532,168 @@ func TestLinkBufferBufferMode(t *testing.T) {
 	bufnode := newLinkBufferNode(0)
 	MustTrue(t, bufnode.getFlag(flagUnmanaged))
 	MustTrue(t, !bufnode.reusable())
+	MustTrue(t, !bufnode.readExposed())
 
 	bufnode = newLinkBufferNode(1)
 	MustTrue(t, !bufnode.getFlag(flagUnmanaged))
 	MustTrue(t, bufnode.reusable())
+	MustTrue(t, !bufnode.readExposed())
+}
+
+func TestLinkBufferReadCopy(t *testing.T) {
+	t.Run("SingleNode", func(t *testing.T) {
+		LinkBufferCap = 128
+		buf := NewLinkBuffer(128)
+		p, _ := buf.Malloc(16)
+		for i := range p {
+			p[i] = byte(i)
+		}
+		buf.Flush()
+
+		dst := make([]byte, 10)
+		n := buf.readCopy(dst)
+		Equal(t, n, 10)
+		for i := 0; i < 10; i++ {
+			Equal(t, dst[i], byte(i))
+		}
+		Equal(t, buf.Len(), 6)
+		// readCopy must not set readExposed
+		MustTrue(t, !buf.read.readExposed())
+	})
+
+	t.Run("MultiNode", func(t *testing.T) {
+		LinkBufferCap = 8
+		buf := NewLinkBuffer(8)
+		p, _ := buf.Malloc(8)
+		for i := range p {
+			p[i] = byte(i)
+		}
+		buf.Flush()
+		p, _ = buf.Malloc(8)
+		for i := range p {
+			p[i] = byte(i + 8)
+		}
+		buf.Flush()
+
+		dst := make([]byte, 16)
+		n := buf.readCopy(dst)
+		Equal(t, n, 16)
+		for i := 0; i < 16; i++ {
+			Equal(t, dst[i], byte(i))
+		}
+		Equal(t, buf.Len(), 0)
+	})
+
+	t.Run("PartialRead", func(t *testing.T) {
+		LinkBufferCap = 128
+		buf := NewLinkBuffer(128)
+		p, _ := buf.Malloc(4)
+		for i := range p {
+			p[i] = byte(i + 1)
+		}
+		buf.Flush()
+
+		// read more than available
+		dst := make([]byte, 16)
+		n := buf.readCopy(dst)
+		Equal(t, n, 4)
+		Equal(t, dst[0], byte(1))
+		Equal(t, dst[3], byte(4))
+		Equal(t, buf.Len(), 0)
+	})
+
+	t.Run("ReleasesNonExposedNodes", func(t *testing.T) {
+		LinkBufferCap = 8
+		buf := NewLinkBuffer(8)
+		buf.Malloc(8)
+		buf.Flush()
+		buf.Malloc(8)
+		buf.Flush()
+		node1 := buf.read
+
+		dst := make([]byte, 16)
+		buf.readCopy(dst)
+		// node1 was not exposed, should be released (head advanced past it)
+		MustTrue(t, buf.head != node1)
+	})
+
+	t.Run("SkipsExposedNodes", func(t *testing.T) {
+		LinkBufferCap = 8
+		buf := NewLinkBuffer(8)
+		p, _ := buf.Malloc(8)
+		for i := range p {
+			p[i] = byte(i)
+		}
+		buf.Flush()
+		buf.Malloc(8)
+		buf.Flush()
+
+		// expose node1 via Peek
+		buf.Peek(4)
+		node1 := buf.read
+		MustTrue(t, node1.readExposed())
+
+		// readCopy past both nodes
+		dst := make([]byte, 16)
+		n := buf.readCopy(dst)
+		Equal(t, n, 16)
+		Equal(t, dst[0], byte(0))
+		// head should stay at exposed node1
+		Equal(t, buf.head, node1)
+
+		// subsequent Release frees the exposed node
+		buf.Release()
+		MustTrue(t, buf.head != node1)
+	})
+
+	// [exposed/consumed] → [not-exposed/consumed] → [partial-consumed/read]
+	t.Run("ExposedThenNonExposedThenPartial", func(t *testing.T) {
+		LinkBufferCap = 8
+		buf := NewLinkBuffer(8)
+		// node1: 8 bytes
+		p, _ := buf.Malloc(8)
+		for i := range p {
+			p[i] = byte(i)
+		}
+		buf.Flush()
+		// node2: 8 bytes
+		p, _ = buf.Malloc(8)
+		for i := range p {
+			p[i] = byte(i + 8)
+		}
+		buf.Flush()
+		// node3: 8 bytes
+		p, _ = buf.Malloc(8)
+		for i := range p {
+			p[i] = byte(i + 16)
+		}
+		buf.Flush()
+
+		// expose node1 via Peek
+		buf.Peek(4)
+		node1 := buf.read
+		node2 := node1.next
+		MustTrue(t, node1.readExposed())
+		MustTrue(t, !node2.readExposed())
+
+		// readCopy 20 bytes: consumes node1(8) + node2(8) + 4 from node3
+		dst := make([]byte, 20)
+		n := buf.readCopy(dst)
+		Equal(t, n, 20)
+		for i := 0; i < 20; i++ {
+			Equal(t, dst[i], byte(i))
+		}
+		Equal(t, buf.Len(), 4)
+
+		// head should be node1 (exposed, kept in chain)
+		Equal(t, buf.head, node1)
+		// node2 was released, node1.next should skip to read (node3)
+		Equal(t, node1.next, buf.read)
+
+		// subsequent Release frees the exposed node
+		buf.Release()
+		MustTrue(t, buf.head == buf.read)
+	})
 }
 
 func BenchmarkLinkBufferConcurrentReadWrite(b *testing.B) {

--- a/nocopy_readwriter.go
+++ b/nocopy_readwriter.go
@@ -225,11 +225,18 @@ func newIOReader(r Reader) *ioReader {
 var _ io.Reader = &ioReader{}
 
 // ioReader implements io.Reader.
+//
+// Deprecated: connection already implements Read directly with optimized buffer access.
+// This wrapper exists only for external Reader implementations.
 type ioReader struct {
 	r Reader
 }
 
 // Read implements io.Reader.
+//
+// BUG: Read calls Release which invalidates any slices previously returned by Next or Peek
+// on the same Reader. Do not mix Next/Peek and Read on the same Reader without first
+// calling Release.
 func (r *ioReader) Read(p []byte) (n int, err error) {
 	l := len(p)
 	if l == 0 {
@@ -283,6 +290,6 @@ func (w *ioWriter) Write(p []byte) (n int, err error) {
 
 // ioReadWriter implements io.ReadWriter.
 type ioReadWriter struct {
-	*ioReader
-	*ioWriter
+	io.Reader
+	io.Writer
 }


### PR DESCRIPTION
Add flagReadExposed to track when a node's buffer has been returned directly to user code via zero-copy Reader methods (Next, Peek, Slice, GetBytes). 
Connection.Read now uses readCopy which copies from nodes without setting this flag, and only releases nodes that are not exposed. 
This preserves buffer validity for prior zero-copy callers until Release.

