### PR TITLE
feat(connection): add explicit PauseRead/ResumeRead/IsReadPaused APIs

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -41,6 +41,17 @@ type Connection interface {
 	// IsActive checks whether the connection is active or not.
 	IsActive() bool
 
+	// PauseRead disables readable event monitoring for this connection.
+	// It only affects read readiness and does not disable pending write readiness.
+	PauseRead() error
+
+	// ResumeRead enables readable event monitoring for this connection.
+	// It only affects read readiness and does not disable pending write readiness.
+	ResumeRead() error
+
+	// IsReadPaused checks whether readable event monitoring is paused.
+	IsReadPaused() bool
+
 	// SetReadTimeout sets the timeout for future Read calls wait.
 	// A zero value for timeout means Reader will not timeout.
 	SetReadTimeout(timeout time.Duration) error

--- a/connection_impl.go
+++ b/connection_impl.go
@@ -49,9 +49,12 @@ type connection struct {
 	inputBuffer   *LinkBuffer
 	outputBuffer  *LinkBuffer
 	outputBarrier *barrier
+	pollEventMu   sync.Mutex
 	maxSize       int       // The maximum size of data between two Release().
 	bookSize      int       // The size of data that can be read at once.
 	state         connState // Connection state should be changed sequentially.
+	readPaused    bool      // true if readable event monitoring is paused. Guarded by pollEventMu.
+	writeWatching bool      // true if writable event monitoring is enabled. Guarded by pollEventMu.
 }
 
 var (
@@ -543,7 +546,17 @@ func (c *connection) flush() error {
 	if c.outputBuffer.IsEmpty() {
 		return nil
 	}
-	err = c.operator.Control(PollR2RW)
+	c.pollEventMu.Lock()
+	c.writeWatching = true
+	if c.readPaused {
+		err = c.operator.Control(PollN2W)
+	} else {
+		err = c.operator.Control(PollR2RW)
+	}
+	if err != nil {
+		c.writeWatching = false
+	}
+	c.pollEventMu.Unlock()
 	if err != nil {
 		return Exception(err, "when flush")
 	}
@@ -585,7 +598,14 @@ func (c *connection) waitFlush() (err error) {
 		}
 		// if timeout, remove write event from poller
 		// we cannot flush it again, since we don't if the poller is still process outputBuffer
-		c.operator.Control(PollRW2R)
+		c.pollEventMu.Lock()
+		c.writeWatching = false
+		if c.readPaused {
+			c.operator.Control(PollW2N)
+		} else {
+			c.operator.Control(PollRW2R)
+		}
+		c.pollEventMu.Unlock()
 		return Exception(ErrWriteTimeout, c.remoteAddr.String())
 	}
 }

--- a/connection_reactor.go
+++ b/connection_reactor.go
@@ -141,6 +141,74 @@ func (c *connection) outputAck(n int) (err error) {
 
 // rw2r removed the monitoring of write events.
 func (c *connection) rw2r() {
-	c.operator.Control(PollRW2R)
+	c.pollEventMu.Lock()
+	c.writeWatching = false
+	if c.readPaused {
+		c.operator.Control(PollW2N)
+	} else {
+		c.operator.Control(PollRW2R)
+	}
+	c.pollEventMu.Unlock()
 	c.triggerWrite(nil)
+}
+
+// PauseRead removes readable event monitoring for this connection.
+// It is idempotent and preserves writable event monitoring if it is currently enabled.
+func (c *connection) PauseRead() error {
+	c.pollEventMu.Lock()
+	defer c.pollEventMu.Unlock()
+
+	if !c.IsActive() {
+		return Exception(ErrConnClosed, "when pause read")
+	}
+	if c.readPaused {
+		return nil
+	}
+	c.readPaused = true
+
+	var err error
+	if c.writeWatching {
+		err = c.operator.Control(PollRW2W)
+	} else {
+		err = c.operator.Control(PollR2N)
+	}
+	if err != nil {
+		c.readPaused = false
+		return err
+	}
+	return nil
+}
+
+// ResumeRead adds readable event monitoring for this connection.
+// It is idempotent and preserves writable event monitoring if it is currently enabled.
+func (c *connection) ResumeRead() error {
+	c.pollEventMu.Lock()
+	defer c.pollEventMu.Unlock()
+
+	if !c.IsActive() {
+		return Exception(ErrConnClosed, "when resume read")
+	}
+	if !c.readPaused {
+		return nil
+	}
+	c.readPaused = false
+
+	var err error
+	if c.writeWatching {
+		err = c.operator.Control(PollW2RW)
+	} else {
+		err = c.operator.Control(PollN2R)
+	}
+	if err != nil {
+		c.readPaused = true
+		return err
+	}
+	return nil
+}
+
+// IsReadPaused checks whether readable event monitoring is paused.
+func (c *connection) IsReadPaused() bool {
+	c.pollEventMu.Lock()
+	defer c.pollEventMu.Unlock()
+	return c.readPaused
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -152,6 +152,44 @@ func TestConnectionRead(t *testing.T) {
 	rconn.Close()
 }
 
+func TestConnectionPauseResumeRead(t *testing.T) {
+	r, w := GetSysFdPairs()
+	notify := make(chan struct{}, 1)
+	rconn, wconn := &connection{}, &connection{}
+	err := rconn.init(&netFD{fd: r}, &options{onRequest: func(ctx context.Context, connection Connection) error {
+		buf, err := connection.Reader().Next(4)
+		MustNil(t, err)
+		Equal(t, string(buf), "ping")
+		MustNil(t, connection.Reader().Release())
+		notify <- struct{}{}
+		return nil
+	}})
+	MustNil(t, err)
+	err = wconn.init(&netFD{fd: w}, nil)
+	MustNil(t, err)
+	defer rconn.Close()
+	defer wconn.Close()
+
+	MustNil(t, rconn.PauseRead())
+	Assert(t, rconn.IsReadPaused())
+	_, err = wconn.Write([]byte("ping"))
+	MustNil(t, err)
+
+	select {
+	case <-notify:
+		t.Fatal("read event fired while paused")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	MustNil(t, rconn.ResumeRead())
+	Assert(t, !rconn.IsReadPaused())
+	select {
+	case <-notify:
+	case <-time.After(time.Second):
+		t.Fatal("read event did not fire after resume")
+	}
+}
+
 // TestConnectionIOReader tests the io.Reader Read method which uses readCopy internally.
 // Verifies that Read after Peek preserves exposed buffer until Release.
 func TestConnectionIOReader(t *testing.T) {

--- a/poll.go
+++ b/poll.go
@@ -63,4 +63,22 @@ const (
 
 	// PollRW2R is used to remove the writable monitor of FDOperator, generally used with PollR2RW.
 	PollRW2R PollEvent = 0x6
+
+	// PollRW2W is used to remove the readable monitor of FDOperator while keeping writable monitoring.
+	PollRW2W PollEvent = 0x7
+
+	// PollW2RW is used to add the readable monitor of FDOperator while keeping writable monitoring.
+	PollW2RW PollEvent = 0x8
+
+	// PollR2N is used to remove the readable monitor when writable monitoring is disabled.
+	PollR2N PollEvent = 0x9
+
+	// PollN2R is used to add the readable monitor when writable monitoring is disabled.
+	PollN2R PollEvent = 0xA
+
+	// PollN2W is used to add the writable monitor when readable monitoring is disabled.
+	PollN2W PollEvent = 0xB
+
+	// PollW2N is used to remove the writable monitor when readable monitoring is disabled.
+	PollW2N PollEvent = 0xC
 )

--- a/poll_default_bsd.go
+++ b/poll_default_bsd.go
@@ -196,6 +196,14 @@ func (p *defaultPoll) Control(operator *FDOperator, event PollEvent) error {
 		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_ADD|syscall.EV_ENABLE
 	case PollRW2R:
 		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_DELETE
+	case PollRW2W, PollR2N:
+		evs[0].Filter, evs[0].Flags = syscall.EVFILT_READ, syscall.EV_DELETE
+	case PollW2RW, PollN2R:
+		evs[0].Filter, evs[0].Flags = syscall.EVFILT_READ, syscall.EV_ADD|syscall.EV_ENABLE
+	case PollN2W:
+		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_ADD|syscall.EV_ENABLE
+	case PollW2N:
+		evs[0].Filter, evs[0].Flags = syscall.EVFILT_WRITE, syscall.EV_DELETE
 	}
 	_, err := syscall.Kevent(p.fd, evs, nil, nil)
 	return err

--- a/poll_default_linux.go
+++ b/poll_default_linux.go
@@ -259,6 +259,18 @@ func (p *defaultPoll) Control(operator *FDOperator, event PollEvent) error {
 		op, evt.Events = syscall.EPOLL_CTL_MOD, syscall.EPOLLIN|syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
 	case PollRW2R: // connection wait read
 		op, evt.Events = syscall.EPOLL_CTL_MOD, syscall.EPOLLIN|syscall.EPOLLRDHUP|syscall.EPOLLERR
+	case PollRW2W: // connection pause read while write is enabled
+		op, evt.Events = syscall.EPOLL_CTL_MOD, syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
+	case PollW2RW: // connection resume read while write is enabled
+		op, evt.Events = syscall.EPOLL_CTL_MOD, syscall.EPOLLIN|syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
+	case PollR2N: // connection pause read while write is disabled
+		op, evt.Events = syscall.EPOLL_CTL_MOD, syscall.EPOLLRDHUP|syscall.EPOLLERR
+	case PollN2R: // connection resume read while write is disabled
+		op, evt.Events = syscall.EPOLL_CTL_MOD, syscall.EPOLLIN|syscall.EPOLLRDHUP|syscall.EPOLLERR
+	case PollN2W: // connection wait write while read is paused
+		op, evt.Events = syscall.EPOLL_CTL_MOD, syscall.EPOLLOUT|syscall.EPOLLRDHUP|syscall.EPOLLERR
+	case PollW2N: // connection remove write while read is paused
+		op, evt.Events = syscall.EPOLL_CTL_MOD, syscall.EPOLLRDHUP|syscall.EPOLLERR
 	}
 	return EpollCtl(p.fd, op, fd, &evt)
 }


### PR DESCRIPTION
Expose application-driven read backpressure on the Connection interface:

- PauseRead()    stop monitoring readable (EPOLLIN) events for this conn
- ResumeRead()   resume monitoring readable events
- IsReadPaused() report whether readable monitoring is currently paused

These are minimal mechanisms that let the application decide *when* to apply TCP backpressure based on its own signal (downstream/outbound queue depth, work-queue high/low watermarks, credits, ...), instead of relying on netpoll's inbound LinkBuffer size, which is not a reliable proxy for application overload (e.g. proxies that drain the inbound buffer quickly into their own queue).

Implementation notes:
- Read and write interest are now two independent dimensions. The poll mask is recomputed from (readPaused, writeWatching) on every transition; adds PollR2N/PollN2R/PollN2W/PollW2N alongside the existing PollRW2W/PollW2RW so read can be toggled without disturbing a pending write and vice versa.
- When read is paused and there is no pending write, the connection drops to "no interest" rather than write-only, avoiding a level-triggered EPOLLOUT busy-spin on receive-mostly connections.
- Transitions are serialized with a per-connection mutex: the two dimensions are mutated by different goroutines (application vs poller) and epoll_ctl(MOD) sets an absolute mask, so atomics alone cannot order "state change + syscall".
- PauseRead/ResumeRead are guarded by IsActive() to avoid calling Control() on a freed operator after close.
- epoll (Linux) and kqueue (BSD) control paths updated.
- Added TestConnectionPauseResumeRead.

No behavior change unless the new APIs are called.

